### PR TITLE
Add a simple NodeJS example and map it

### DIFF
--- a/app/examples/github-actions/nodejs/npm_build_test.yaml
+++ b/app/examples/github-actions/nodejs/npm_build_test.yaml
@@ -1,0 +1,16 @@
+name: Node.js CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # <-- Likely doesnot need mapping, given we run a checkout on each step
+      - name: Use Node.js
+        uses: actions/setup-node@v3 # <-- This would be removed in favour of using a Dockerfile; we don't run on single instance
+        with:
+          node-version: '20.x'
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test

--- a/app/examples/github-actions/nodejs/npm_build_test_mapped.yaml
+++ b/app/examples/github-actions/nodejs/npm_build_test_mapped.yaml
@@ -1,0 +1,9 @@
+steps:
+  - label: ":npm: Run tests"
+    command:
+      - npm install
+      - npm run build --if-present
+      - npm test
+    plugins:
+      - docker#v5.9.0:
+          image: node:slim


### PR DESCRIPTION
## Changes
* Added a `dir` for github-actions (hyphenated as that seems convention in this app)
* Added a simple `npm install|build|test` step in GHA format
* Mapped the above to a Buildkite pipeline
    * Shows where we would use a `plugin` instead of `uses` 
