### PR TITLE
SUP-1465-Setup testing using rspec

### DIFF
--- a/app/.rspec
+++ b/app/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -7,3 +7,4 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'rack'
 gem 'rackup' # necessary for starting the HTTP interface
 gem 'rouge'
+gem 'rspec'

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -1,20 +1,35 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (3.0.7)
+    diff-lcs (1.5.0)
+    rack (3.0.8)
     rackup (2.1.0)
       rack (>= 3)
       webrick (~> 1.8)
-    rouge (4.1.2)
+    rouge (4.1.3)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
     webrick (1.8.1)
 
 PLATFORMS
-  x86_64-linux
+  arm64-darwin-22
 
 DEPENDENCIES
   rack
   rackup
   rouge
+  rspec
 
 BUNDLED WITH
-   2.4.10
+   2.4.20

--- a/app/spec/lib/bk/compat/gha_actions_spec.rb
+++ b/app/spec/lib/bk/compat/gha_actions_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Github Actions Parser' do
+
+  context 'do stuff' do 
+    it 'does stuff' do
+      # puts JSON.parse(subject.to_h.to_json).to_yaml
+    end
+  end
+end


### PR DESCRIPTION
This PR just setups the necessary config to run rspec.

Initially, the tests were not run and was just ignored. Now, we can see them failing - it means `rspec` is now correctly configured in the project.


Tests for CircleCI is currently failing with the following errors:

```
Failures:

  1) BK::Compat::CircleCI segmentio-aws-okta.yml does stuff
     Failure/Error:
       BK::Compat::CircleCI.parse_file("spec/examples/circleci/#{e.example_group.description}",
                                       workflow: 'test-dist-publish-linux')
     
     NoMethodError:
       undefined method `parse_file' for Circle CI:Class
     # ./spec/lib/bk/compat/circleci_spec.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/lib/bk/compat/circleci_spec.rb:25:in `block (3 levels) in <top (required)>'

Finished in 0.00178 seconds (files took 0.31713 seconds to load)
3 examples, 1 failure

Failed examples:

rspec ./spec/lib/bk/compat/circleci_spec.rb:24 # BK::Compat::CircleCI segmentio-aws-okta.yml does stuff
```

This PR also includes a dummy test for the GitHub Actions parser.
