### PR TITLE
Expression parser

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem 'rack'
 gem 'rackup' # necessary for starting the HTTP interface
 gem 'rouge'
+gem 'parslet'
 
 group :development, :test do
   gem 'rspec'

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     awesome_print (1.9.2)
     diff-lcs (1.5.0)
+    parslet (2.0.0)
     rack (3.0.7)
     rackup (2.1.0)
       rack (>= 3)
@@ -30,6 +31,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  parslet
   rack
   rackup
   rouge

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -50,7 +50,7 @@ module BK
 
       rule(:functions) { arg_functions | status_functions }
 
-      rule(:arg_functions) { func_name.as(:func) >> str('(') >> arguments.as(:args) >> str(')') }
+      rule(:arg_functions) { func_name.as(:func) >> str('(') >> arguments.repeat(0, 1).as(:args) >> str(')') }
       rule(:arguments) { expression >> (str(',') >> expression).repeat }
       rule(:func_name) do
         str('contains') |

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'parslet'
+
+module BK
+  module Compat
+    # parse GHA expressions
+    # https://docs.github.com/en/actions/learn-github-actions/expressions
+    class ExpressionParser < Parslet::Parser
+      rule(:space) { match('\s').repeat(1) }
+      rule(:space?) { space.maybe }
+      rule(:quote) { match('\'') }
+
+      rule(:expression) { literals | parens | operators | functions }
+
+      rule(:literals) { boolean | null | number | string }
+      rule(:boolean) { str('false') | str('true') }
+      rule(:null) { str('null') }
+      rule(:number) { match('[0-9]').repeat(1) } # TODO: support other numbers
+      rule(:string) { quoted_string | unquoted_string }
+      rule(:quoted_string) { quote >> (unquoted_string | match('\'\'')).repeat >> quote }
+      rule(:unquoted_string) { match('[^\']').repeat }
+
+      rule(:parens) { match('(') >> space? >> expression >> space? >> match(')') }
+
+      rule(:operators) { ops | unary | logical }
+      rule(:ops) { expression >> space? >> operators >> space? >> expression }
+      rule(:unary) { match('!') >> space? >> expression } # can not name it "not"
+      rule(:operators) do
+        match('<=') |
+          match('<') |
+          match('>=') |
+          match('>') |
+          match('==') |
+          match('!=') |
+          match('&&') |
+          match('||')
+      end
+
+      rule(:functions) { arg_functions | status_functions }
+
+      rule(:arg_functions) { func_name >> match('(') >> space? >> arguments >> space? >> match(')') }
+      rule(:arguments) { expression >> (match(',') >> space? >> expression).repeat }
+      rule(:func_name) do
+        match('contains') |
+          match('startsWith') |
+          match('endsWith') |
+          match('format') |
+          match('join') |
+          match('toJSON') |
+          match('fromJSON') |
+          match('hashFiles')
+      end
+      rule(:status_functions) { status_func >> match('(') >> space? >> match(')') }
+      rule(:status_func) do
+        match('success') |
+          match('always') |
+          match('cancelled') |
+          match('failure')
+      end
+
+      root(:expression)
+    end
+  end
+end

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -28,9 +28,8 @@ module BK
       rule(:exp) { float >> match('[eE]') >> signed_integer }
 
       # Docs state that strings must be quoted (unless they are not surrounded with ${{ }})
-      rule(:string) do
-        quote >> (UnquotedStringParser.new >> (str("''") >> UnquotedStringParser.new).repeat).as(:str) >> quote
-      end
+      rule(:string) { quote >> (unquoted_string >> (str("''") >> unquoted_string).repeat).as(:str) >> quote }
+      rule(:unquoted_string) { match('[^\']').repeat }
 
       rule(:parens) { (str('(') >> expression >> str(')')).as(:paren) }
 
@@ -72,12 +71,6 @@ module BK
       end
 
       root(:expression)
-    end
-
-    # Unquoted strings are just characters that don't have single quotes
-    class UnquotedStringParser < Parslet::Parser
-      root(:unquoted_string)
-      rule(:unquoted_string) { match('[^\']').repeat }
     end
   end
 end

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -20,7 +20,7 @@ module BK
       rule(:boolean) { str('false') | str('true') }
       rule(:null) { str('null') }
 
-      rule(:number) { signed_integer | float | hex | exp }
+      rule(:number) { hex | exp | float | signed_integer }
       rule(:integer) { match('[0-9]').repeat(1) }
       rule(:signed_integer) { str('-').maybe >> integer }
       rule(:float) { signed_integer >> str('.') >> integer }

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -16,7 +16,7 @@ module BK
       # TODO: allow operations to include other operations
       rule(:expression) { operations | base_exp }
 
-      rule(:literals) { boolean.as(:bool) | null.as(:null) | number.as(:num) | string }
+      rule(:literals) { boolean.as(:bool) | null.as(:null) | number.as(:num) | string | context }
       rule(:boolean) { str('false') | str('true') }
       rule(:null) { str('null') }
 
@@ -69,6 +69,23 @@ module BK
           str('cancelled') |
           str('failure')
       end
+
+      rule(:context) { (ctx_name >> (str('.') >> atom).repeat(1)).as(:context) }
+      rule(:ctx_name) do
+        str('env') |
+          str('github') |
+          str('inputs') |
+          str('jobs') |
+          str('job') |
+          str('matrix') |
+          str('needs') |
+          str('runner') |
+          str('secrets') |
+          str('steps') |
+          str('strategy') |
+          str('vars')
+      end
+      rule(:atom) { str('*') | (match('[_a-zA-Z]') >> match('[a-zA-Z0-9_-]').repeat) }
 
       root(:expression)
     end

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -85,7 +85,8 @@ module BK
           str('strategy') |
           str('vars')
       end
-      rule(:atom) { str('*') | (match('[_a-zA-Z]') >> match('[a-zA-Z0-9_-]').repeat) }
+      rule(:atom) { str('*') | (match('[_a-zA-Z]') >> match('[a-zA-Z0-9_-]').repeat >> index.maybe) }
+      rule(:index) { str('[') >> match('[a-zA-Z0-9_-]').repeat >> str(']') }
 
       root(:expression)
     end
@@ -173,5 +174,14 @@ module BK
         "Invalid expression #{str}"
       end
     end
+
+    # Helpful to debug how a string is parsed
+    # From https://stackoverflow.com/a/15727569/1352026
+    # class Parslet::Atoms::Context
+    #   def lookup(obj, pos)
+    #     p obj
+    #     @cache[pos][obj.object_id]
+    #   end
+    # end
   end
 end

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/java-spring-boot-bmi.yaml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/java-spring-boot-bmi.yaml.snap
@@ -29,14 +29,14 @@ steps:
 - commands:
   - "# action actions/checkout@v3 can not be translated just yet"
   - echo '~~~ Add Server key'
-  - touch key.txt && echo "Context element secrets.SERVER_KEY  can not be translated
+  - touch key.txt && echo "Context element secrets.SERVER_KEY can not be translated
     (yet)" > key.txt
   - chmod 600 key.txt
   - echo '~~~ Deploy the application'
   - "("
-  - SERVER_HOST="Context element secrets.SERVER_HOST  can not be translated (yet)"
-  - SERVER_PORT="Context element secrets.SERVER_PORT  can not be translated (yet)"
-  - SERVER_USER="Context element secrets.SERVER_USER  can not be translated (yet)"
+  - SERVER_HOST="Context element secrets.SERVER_HOST can not be translated (yet)"
+  - SERVER_PORT="Context element secrets.SERVER_PORT can not be translated (yet)"
+  - SERVER_USER="Context element secrets.SERVER_USER can not be translated (yet)"
   - set -e
   - "./deploy.sh"
   - ")"

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/laravel-tests.yml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/laravel-tests.yml.snap
@@ -8,7 +8,7 @@ steps:
   - "# action nick-fields/retry@v2 can not be translated just yet"
   - echo '~~~ Execute tests'
   - "("
-  - DB_PORT="Context element job.services.mysql.ports[3306]  can not be translated
+  - DB_PORT="Context element job.services.mysql.ports[3306] can not be translated
     (yet)"
   - DB_USERNAME="root"
   - DYNAMODB_CACHE_TABLE="laravel_dynamodb_test"

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/pest-tests.yml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/pest-tests.yml.snap
@@ -4,19 +4,17 @@ steps:
   - "# action actions/checkout@v2 can not be translated just yet"
   - "# action shivammathur/setup-php@v2 can not be translated just yet"
   - echo '~~~ Setup Problem Matches'
-  - echo "::add-matcher::Context element runner.tool_cache  can not be translated
-    (yet)/php.json"
-  - echo "::add-matcher::Context element runner.tool_cache  can not be translated
-    (yet)/phpunit.json"
+  - echo "::add-matcher::Context element runner.tool_cache can not be translated (yet)/php.json"
+  - echo "::add-matcher::Context element runner.tool_cache can not be translated (yet)/phpunit.json"
   - echo '~~~ Install PHP dependencies'
-  - composer update --Context element matrix.dependency-version  can not be translated
+  - composer update --Context element matrix.dependency-version can not be translated
     (yet) --no-interaction --no-progress --ansi
   - echo '~~~ Unit Tests'
   - composer test:unit
   - echo '~~~ Unit Tests in Parallel'
   - composer test:parallel
   agents:
-    runs-on: Context element matrix.os  can not be translated (yet)
+    runs-on: Context element matrix.os can not be translated (yet)
   matrix:
     setup:
       os:

--- a/app/spec/lib/bk/compat/gha/expressions_spec.rb
+++ b/app/spec/lib/bk/compat/gha/expressions_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'parslet/rig/rspec'
+
+require_relative '../../../../../lib/bk/compat/parsers/gha/expressions'
+
+RSpec.describe BK::Compat::ExpressionParser do
+  let(:p) { BK::Compat::ExpressionParser.new }
+  context 'bools' do
+    subject { p.boolean }
+
+    %w[true false].freeze.each do |value|
+      it "should parse #{value}" do
+        expect(subject).to parse(value)
+        expect(p.parse(value)).to include(:bool)
+      end
+    end
+  end
+
+  context 'numbers' do
+    subject { p.number }
+
+    {
+      integer: '711',
+      'negative integer': '-171',
+      floats: '-9.2',
+      hex: '0xff',
+      scientific: '-2.99e-2'
+    }.each do |desc, value|
+      it "should parse #{desc}" do
+        expect(subject).to parse(value)
+        expect(p.parse(value)).to include(:num)
+      end
+    end
+  end
+
+  context 'null' do
+    it 'should parse null' do
+      expect(p.null).to parse('null')
+      expect(p.parse('null')).to include(:null)
+    end
+  end
+
+  context 'string' do
+    subject { p.string }
+
+    it 'should parse single quoted strings' do
+      expect(subject).to parse('\'string\'')
+      expect(p.parse('\'string\'')).to include(:str)
+
+      expect(subject).to parse('\'a\'\'b\'')
+      expect(p.parse('\'a\'\'b\'')).to include(:str)
+    end
+
+    it 'should parse the empty string' do
+      expect(subject).to parse('\'\'')
+      expect(p.parse('\'\'')).to include(:str)
+    end
+  end
+
+  context 'parenthesis' do
+    subject { p.parens }
+
+    it 'should parse parenthesised expressions' do
+      expect(subject).to parse('(1)')
+      expect(p.parse('(1)')).to include(:paren)
+    end
+
+    it 'should parse nested parenthesis' do
+      expect(subject).to parse('((1))')
+      exp = p.parse('((1))')
+      expect(exp).to include(:paren)
+      expect(exp[:paren]).to include(:paren)
+    end
+  end
+
+  context 'not' do
+    it 'should parse unary not' do
+      expect(p.unary_op).to parse('!1')
+      expect(p.parse('!1')).to include(:not)
+    end
+  end
+
+  context 'functions' do
+    subject { p.arg_functions }
+
+    func_names = %w[contains startsWith endsWith format join toJSON fromJSON hashFiles].freeze
+    arg_amount = %w[() (1) (1,2) (1,2,3,4,5,6)].freeze
+
+    func_names.each do |name|
+      it "should parse function #{name}" do
+        arg_amount.each do |params|
+          funcall = "#{name}#{params}"
+          expect(subject).to parse(funcall)
+
+          # make sure it is properly marked in resulting tree
+          exp = p.parse(funcall)
+          expect(exp).to include(:func)
+          expect(exp[:func]).to eq(name)
+          expect(exp).to include(:args)
+          expect(exp[:args]).to be_a(Array)
+        end
+        # ensure that without parenthesis it is not valid
+        expect { subject.parse(name) }.to raise_error Parslet::ParseFailed
+      end
+    end
+  end
+
+  context 'status functions' do
+    subject { p.status_functions }
+
+    status_names = %w[success always cancelled failure].freeze
+
+    status_names.each do |name|
+      it "should parse function #{name}" do
+        funcall = "#{name}()"
+        expect(subject).to parse(funcall)
+        exp = p.parse(funcall)
+        expect(exp).to include(:status)
+
+        # ensure that without parenthesis it is not valid
+        expect { subject.parse(name) }.to raise_error Parslet::ParseFailed
+      end
+    end
+  end
+
+  context 'operations' do
+    subject { p.operations }
+
+    ops = %w[<= < >= > == != && ||].freeze
+    ops.each do |op|
+      it "can parse #{op} operations" do
+        value = "1 #{op} 2"
+        expect(subject).to parse(value)
+
+        exp = p.parse(value)
+
+        # this is how infix_expressions return stuff
+        expect(exp).to include(:l)
+        expect(exp).to include(:r)
+        expect(exp).to include(:o)
+      end
+
+      it "rejects invalid expressions including #{op}" do
+        expect { p.parse("1 #{op}") }.to raise_error Parslet::ParseFailed
+        expect { p.parse(op) }.to raise_error Parslet::ParseFailed
+        expect { p.parse("#{op} 2") }.to raise_error Parslet::ParseFailed
+      end
+    end
+  end
+end

--- a/app/spec/lib/bk/compat/gha/expressions_spec.rb
+++ b/app/spec/lib/bk/compat/gha/expressions_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe BK::Compat::ExpressionParser do
         expect(subject).to parse("#{ctx}.one")
         expect(subject).to parse("#{ctx}.one.two1")
         expect(subject).to parse("#{ctx}.*.two.thr2ee")
-        expect(subject).to parse("#{ctx}.on_e.*.three")
-        expect(subject).to parse("#{ctx}.one.tw-o.*")
+        expect(subject).to parse("#{ctx}.on_e[sd].*.three")
+        expect(subject).to parse("#{ctx}.one.tw-o[1].*")
         expect(subject).to parse("#{ctx}.*._two.*")
 
         expect { subject.parse("#{ctx}.0invalid") }.to raise_error Parslet::ParseFailed

--- a/app/spec/lib/bk/compat/gha/expressions_spec.rb
+++ b/app/spec/lib/bk/compat/gha/expressions_spec.rb
@@ -149,4 +149,27 @@ RSpec.describe BK::Compat::ExpressionParser do
       end
     end
   end
+
+  context 'contexts' do
+    subject { p.context }
+
+    contexts = %w[github inputs job jobs matrix needs runner secrets steps strategy vars].freeze
+    contexts.each do |ctx|
+      it "can parse #{ctx}" do
+        expect(subject).to parse("#{ctx}.one")
+        expect(subject).to parse("#{ctx}.one.two1")
+        expect(subject).to parse("#{ctx}.*.two.thr2ee")
+        expect(subject).to parse("#{ctx}.on_e.*.three")
+        expect(subject).to parse("#{ctx}.one.tw-o.*")
+        expect(subject).to parse("#{ctx}.*._two.*")
+
+        expect { subject.parse("#{ctx}.0invalid") }.to raise_error Parslet::ParseFailed
+        expect { subject.parse("#{ctx}.-invalid") }.to raise_error Parslet::ParseFailed
+        expect { subject.parse("#{ctx}.") }.to raise_error Parslet::ParseFailed
+        expect { subject.parse(ctx) }.to raise_error Parslet::ParseFailed
+
+        expect(p.parse("#{ctx}.one.two")).to include(:context)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Updates Github Actions expression implementation to a full-blown parser. For this I am using Parslet to create a parser and then transform it.

I added tests to the whole parsing code, but did not have time to do the same on the transformation and context functions. I believe that the existing tests for pipeline translation do take some of the burden of that, though.

I was able to re-use all of the existing code I had done for contexts but now moved it from `steps` to `expressions` and its own class.