### PR TITLE
SUP-1519: actions/setup-go 

### DIFF
--- a/app/examples/github-actions/go-test-version.yaml
+++ b/app/examples/github-actions/go-test-version.yaml
@@ -1,0 +1,27 @@
+# This workflow will build a golang project, source: https://github.com/actions/starter-workflows/blob/main/ci/go.yml 
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: master 
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '>=1.13.1'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...
+

--- a/app/lib/bk/compat/parsers/gha/steps.rb
+++ b/app/lib/bk/compat/parsers/gha/steps.rb
@@ -42,6 +42,15 @@ module BK
               'image' => image_string
             }
           )
+        when /\Aactions\/setup-go@v\d+\z/
+          go_version = step.dig('with', 'go-version').gsub!(/[>=^]/,'') || 'latest'
+          image_string = "golang:#{go_version}"
+          BK::Compat::Plugin.new(
+            name: 'docker',
+            config: {
+              'image' => image_string
+            }
+          )
         when /docker\/login-action.*/
           BK::Compat::Plugin.new(
             name: 'docker-login',

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/go-test-version.yaml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/go-test-version.yaml.snap
@@ -1,0 +1,15 @@
+---
+steps:
+- commands:
+  - "# action actions/checkout@v3 is not necessary in Buildkite"
+  - echo '~~~ Build'
+  - go build -v ./...
+  - echo '~~~ Test'
+  - go test -v ./...
+  plugins:
+  - docker#v5.7.0:
+      image: golang:1.13.1
+  agents:
+    runs-on: ubuntu-latest
+  label: ":github: build"
+  key: build

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/go-test.yml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/go-test.yml.snap
@@ -2,11 +2,13 @@
 steps:
 - commands:
   - "# action actions/checkout@v3 is not necessary in Buildkite"
-  - "# action actions/setup-go@v4 can not be translated just yet"
   - echo '~~~ Build'
   - go build -v ./...
   - echo '~~~ Test'
   - go test -v ./...
+  plugins:
+  - docker#v5.7.0:
+      image: golang:latest
   agents:
     runs-on: ubuntu-latest
   label: ":github: build"


### PR DESCRIPTION
Added `actions/setup-go@vX` to the supported uses translations 

The `go_version` supports `^` and `>=` syntax - these stripped off for filling into the image string