### PR TITLE
Service mapping

### DIFF
--- a/app/lib/bk/compat/parsers/gha/jobs.rb
+++ b/app/lib/bk/compat/parsers/gha/jobs.rb
@@ -2,6 +2,7 @@
 
 require_relative 'concurrency'
 require_relative 'matrix'
+require_relative 'services'
 require_relative 'steps'
 
 module BK
@@ -15,7 +16,11 @@ module BK
         config['steps'].each { |step| bk_step << translate_step(step) }
         bk_step.agents.update(config.slice('runs-on'))
         bk_step.depends_on = Array(config['needs'])
+
+        # these two should be last because they need to execute at the end
         bk_step << translate_outputs(config['outputs'], name)
+        set_services(bk_step, config['services'])
+
         bk_step.instantiate
       end
 

--- a/app/lib/bk/compat/parsers/gha/services.rb
+++ b/app/lib/bk/compat/parsers/gha/services.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module BK
+  module Compat
+    # Translate services to docker commands
+    class GitHubActions
+      def set_services(bk_step, services)
+        return nil if services.nil?
+
+        bk_step.prepend_commands('# It may be a good idea to use docker compose to start up job-specific services')
+        bk_step.prepend_commands(*docker_cmds(services).compact)
+
+        bk_step.add_commands("docker stop #{services.keys}")
+      end
+
+      def docker_cmds(services)
+        services.map do |name, config|
+          # All options map directly to a docker `create` command
+          envs = config['env'].map { |k, v| "--env \"#{k}='#{v}'\"" }.join(' ')
+          ports = config['ports'].map { |p| "--expose '#{p}'" }.join(' ')
+          vols = config['volumes'].map { |v| "--volume '#{v}'" }.join(' ')
+
+          [
+            config.include?('credentials') ? '# Warning: you should use the docker-login plugin to authenticate' : nil,
+            "docker start --rm -d --name #{name} #{envs} #{ports} #{vols} #{config['options']} #{config['image']}"
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/lib/bk/compat/parsers/gha/services.rb
+++ b/app/lib/bk/compat/parsers/gha/services.rb
@@ -17,14 +17,15 @@ module BK
       def docker_cmds(services)
         services.map do |name, config|
           # All options map directly to a docker `create` command
-          envs = config.fetch('env', {}).map { |k, v| "--env \"#{k}='#{v}'\"" }.join(' ')
-          ports = config.fetch('ports', []).map { |p| "--expose '#{p}'" }.join(' ')
-          vols = config.fetch('volumes', []).map { |v| "--volume '#{v}'" }.join(' ')
+          envs = config.fetch('env', {}).map { |k, v| "--env \"#{k}='#{v}'\"" }
+          ports = config.fetch('ports', []).map { |p| "--expose '#{p}'" }
+          vols = config.fetch('volumes', []).map { |v| "--volume '#{v}'" }
 
+          opts = [envs, ports, vols, config.fetch('options', [])].flatten.join(' ')
           [
             "echo 'Starting #{name} service'",
             config.include?('credentials') ? '# Warning: you should use the docker-login plugin to authenticate' : nil,
-            "docker start --rm -d --name #{name} #{envs} #{ports} #{vols} #{config['options']} #{config['image']}"
+            "docker start --rm -d --name #{name} #{opts} #{config['image']}"
           ]
         end
       end

--- a/app/lib/bk/compat/parsers/gha/services.rb
+++ b/app/lib/bk/compat/parsers/gha/services.rb
@@ -7,20 +7,22 @@ module BK
       def set_services(bk_step, services)
         return nil if services.nil?
 
-        bk_step.prepend_commands('# It may be a good idea to use docker compose to start up job-specific services')
-        bk_step.prepend_commands(*docker_cmds(services).compact)
+        cmds = ['# It may be a good idea to use docker compose to start up job-specific services']
+        cmds.concat(docker_cmds(services).flatten)
+        bk_step.prepend_commands(cmds.compact)
 
-        bk_step.add_commands("docker stop #{services.keys}")
+        bk_step.add_commands("docker stop #{services.keys.join(' ')}")
       end
 
       def docker_cmds(services)
         services.map do |name, config|
           # All options map directly to a docker `create` command
-          envs = config['env'].map { |k, v| "--env \"#{k}='#{v}'\"" }.join(' ')
-          ports = config['ports'].map { |p| "--expose '#{p}'" }.join(' ')
-          vols = config['volumes'].map { |v| "--volume '#{v}'" }.join(' ')
+          envs = config.fetch('env', {}).map { |k, v| "--env \"#{k}='#{v}'\"" }.join(' ')
+          ports = config.fetch('ports', []).map { |p| "--expose '#{p}'" }.join(' ')
+          vols = config.fetch('volumes', []).map { |v| "--volume '#{v}'" }.join(' ')
 
           [
+            "echo 'Starting #{name} service'",
             config.include?('credentials') ? '# Warning: you should use the docker-login plugin to authenticate' : nil,
             "docker start --rm -d --name #{name} #{envs} #{ports} #{vols} #{config['options']} #{config['image']}"
           ]

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/laravel-tests.yml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/laravel-tests.yml.snap
@@ -1,6 +1,18 @@
 ---
 steps:
 - commands:
+  - "# It may be a good idea to use docker compose to start up job-specific services"
+  - echo 'Starting memcached service'
+  - docker start --rm -d --name memcached --expose '11211:11211' memcached:1.6-alpine
+  - echo 'Starting mysql service'
+  - docker start --rm -d --name mysql --env "MYSQL_ALLOW_EMPTY_PASSWORD='true'" --env
+    "MYSQL_DATABASE='forge'" --expose '33306:3306' --health-cmd="mysqladmin ping"
+    --health-interval=10s --health-timeout=5s --health-retries=3 mysql:5.7
+  - echo 'Starting redis service'
+  - docker start --rm -d --name redis --expose '6379:6379' --entrypoint redis-server
+    redis:7.0
+  - echo 'Starting dynamodb service'
+  - docker start --rm -d --name dynamodb --expose '8888:8000' amazon/dynamodb-local:2.0.0
   - "# action actions/checkout@v4 is not necessary in Buildkite"
   - "# action shivammathur/setup-php@v2 can not be translated just yet"
   - "# action nick-fields/retry@v2 can not be translated just yet"
@@ -17,6 +29,7 @@ steps:
   - AWS_SECRET_ACCESS_KEY="randomSecret"
   - vendor/bin/phpunit --display-deprecation
   - ")"
+  - docker stop memcached mysql redis dynamodb
   artifact_paths:
   - vendor/orchestra/testbench-core/laravel/storage/logs/**/*
   agents:


### PR DESCRIPTION
Original idea was to use docker compose, but [GHA apparently map directly to `docker create` commands](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idservicesservice_idoptions) and it would make the setup a lot easier than writing a file and then calling `docker compose`