### PR TITLE
SUP-1522: Supported GitHub context variable replacement to `BUILDKITE_x` variables

### DIFF
--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -122,7 +122,6 @@ module BK
 
     class GithubContext
       @github_bk_context_mapping = {
-        "action" => "BUILDKITE_PIPELINE_NAME",
         "actor" => "BUILDKITE_BUILD_AUTHOR",
         "job" => "BUILDKITE_JOB_ID",
         "ref_name" => "BUILDKITE_BRANCH",

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -188,13 +188,9 @@ module BK
       end
 
       def self.replace_context_github(var_name)  
-        translated_var = @github_bk_context_mapping[var_name]
-        case translated_var
-        when String
-          "$#{translated_var}"
-        when nil
-          raise NoMethodError
-        end
+        raise NoMethodError unless @github_bk_context_mapping.include?(var_name)
+        
+        "$$#{@github_bk_context_mapping[var_name]}"
       end
 
       def self.replace_context_needs_outputs(job, path_list)

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -125,10 +125,11 @@ module BK
         "action" => "BUILDKITE_PIPELINE_NAME",
         "actor" => "BUILDKITE_BUILD_AUTHOR",
         "job" => "BUILDKITE_JOB_ID",
-        "sha" => "BUILDKITE_COMMIT",
+        "ref_name" => "BUILDKITE_BRANCH",
         "run_attempt" => "BUILDKITE_RETRY_COUNT",
         "run_id" => "BUILDKITE_BUILD_ID",
         "run_number" => "BUILDKITE_BUILD_NUMBER",
+        "sha" => "BUILDKITE_COMMIT",
         "triggering_actor" => "BUILDKITE_BUILD_CREATOR",
         "workflow" => "BUILDKITE_PIPELINE_NAME"
       }

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -121,6 +121,18 @@ module BK
     end
 
     class GithubContext
+      @github_bk_context_mapping = {
+        "action" => "BUILDKITE_PIPELINE_NAME",
+        "actor" => "BUILDKITE_BUILD_AUTHOR",
+        "job" => "BUILDKITE_JOB_ID",
+        "sha" => "BUILDKITE_COMMIT",
+        "run_attempt" => "BUILDKITE_RETRY_COUNT",
+        "run_id" => "BUILDKITE_BUILD_ID",
+        "run_number" => "BUILDKITE_BUILD_NUMBER",
+        "triggering_actor" => "BUILDKITE_BUILD_CREATOR",
+        "workflow" => "BUILDKITE_PIPELINE_NAME"
+      }
+
       def self.replace(str)
         context, rest = str.split('.', 2)
         send("replace_context_#{context}", rest)
@@ -154,20 +166,14 @@ module BK
         end
       end
 
-      def self.replace_context_github(var_name)
-        github_context_map = {
-          "action" => "BUILDKITE_PIPELINE_NAME",
-          "actor" => "BUILDKITE_BUILD_AUTHOR",
-          "job" => "BUILDKITE_JOB_ID",
-          "sha" => "BUILDKITE_COMMIT",
-          "run_attempt" => "BUILDKITE_RETRY_COUNT",
-          "run_id" => "BUILDKITE_BUILD_ID",
-          "run_number" => "BUILDKITE_BUILD_NUMBER",
-          "triggering_actor" => "BUILDKITE_BUILD_CREATOR",
-          "workflow" => "BUILDKITE_PIPELINE_NAME"
-        }
-        
-        "$#{github_context_map[var_name]}"
+      def self.replace_context_github(var_name)  
+        translated_var = @github_bk_context_mapping[var_name]
+        case translated_var
+        when String
+          "$#{translated_var}"
+        when nil
+          raise NoMethodError
+        end
       end
 
       def self.replace_context_needs_outputs(job, path_list)

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -154,6 +154,22 @@ module BK
         end
       end
 
+      def self.replace_context_github(var_name)
+        github_context_map = {
+          "action" => "BUILDKITE_PIPELINE_NAME",
+          "actor" => "BUILDKITE_BUILD_AUTHOR",
+          "job" => "BUILDKITE_JOB_ID",
+          "sha" => "BUILDKITE_COMMIT",
+          "run_attempt" => "BUILDKITE_RETRY_COUNT",
+          "run_id" => "BUILDKITE_BUILD_ID",
+          "run_number" => "BUILDKITE_BUILD_NUMBER",
+          "triggering_actor" => "BUILDKITE_BUILD_CREATOR",
+          "workflow" => "BUILDKITE_PIPELINE_NAME"
+        }
+        
+        "$#{github_context_map[var_name]}"
+      end
+
       def self.replace_context_needs_outputs(job, path_list)
         if path_list.empty?
           # format of the resulting output is probably not the same


### PR DESCRIPTION
Maps `${{ github.x }}` contexts to supported and relevant `BUILDKITE_y` variables when encountered in a passed through action YAML. 

Context name | Buildkite Environment Variable
--- | --- | 
`actor` | `BUILDKITE_BUILD_AUTHOR` |
`job` |`BUILDKITE_JOB_ID` |
`ref_name` | `BUILDKITE_BRANCH` |
`run_attempt` | `BUILDKITE_RETRY_COUNT` |
`run_id` | `BUILDKITE_BUILD_ID` |
`run_number` | `BUILDKITE_BUILD_NUMBER` |
`sha` | `BUILDKITE_COMMIT` |
`triggering_actor` | `BUILDKITE_BUILD_CREATOR` |
`workflow` | `BUILDKITE_PIPELINE_NAME` |