### PR TITLE
`if` key support

### DIFF
--- a/app/lib/bk/compat/parsers/gha/jobs.rb
+++ b/app/lib/bk/compat/parsers/gha/jobs.rb
@@ -18,6 +18,7 @@ module BK
         config['steps'].each { |step| bk_step << translate_step(step) }
         bk_step.agents.update(config.slice('runs-on'))
         bk_step.depends_on = Array(config['needs'])
+        bk_step.conditional = generate_if(config['if']) if config['if']
 
         # these two should be last because they need to execute at the end
         bk_step << translate_outputs(config['outputs'], name)
@@ -35,6 +36,11 @@ module BK
           timeout_in_minutes: config['timeout-minutes'],
           soft_fail: config['continue-on-error']
         )
+      end
+
+      def generate_if(str)
+        # if is an expression but it can be missing the enclosing ${{}}
+        str.strip.start_with?('${{') ? str : "${{ #{str} }}"
       end
 
       def translate_outputs(outputs, job_name)

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/java-spring-boot-bmi.yaml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/java-spring-boot-bmi.yaml.snap
@@ -34,6 +34,7 @@ steps:
   label: ":github: docker-build"
   key: docker-build
   branches: main
+  if: Context element github.ref can not be translated (yet) == refs/heads/main
 - commands:
   - "# action actions/checkout@v3 is not necessary in Buildkite"
   - echo '~~~ Add Server key'
@@ -54,3 +55,4 @@ steps:
   label: ":github: deploy"
   key: deploy
   branches: main
+  if: Context element github.ref can not be translated (yet) == refs/heads/main

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/pest-tests.yml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/pest-tests.yml.snap
@@ -31,3 +31,5 @@ steps:
     adjustments: []
   label: ":github: ci"
   key: ci
+  if: Context element github.event_name can not be translated (yet) != schedule ||
+    Context element github.repository can not be translated (yet) == pestphp/pest


### PR DESCRIPTION
Documentation states that `if` must be treated as an expression, even when it is missing the enclosing `${{}}`.

Note that this PR will have conflicts with #57 as there is overlap in the snapshots updated (I would suggest merging the other one first)