### PR TITLE
steps context support

### DIFF
--- a/app/examples/github-actions/outputs.yaml
+++ b/app/examples/github-actions/outputs.yaml
@@ -20,3 +20,5 @@ jobs:
           OUTPUT1: ${{needs.job1.outputs.output1}}
           OUTPUT2: ${{needs.job1.outputs.output2}}
         run: echo "$OUTPUT1 $OUTPUT2"
+      - run: echo "${{ steps.step1.outcome }}"
+      - run: echo "${{ steps.step2.conclussion }}"

--- a/app/lib/bk/compat.rb
+++ b/app/lib/bk/compat.rb
@@ -25,5 +25,13 @@ module BK
         "#{first}#{second}"
       end
     end
+
+    # ensure string is a valid(ish) shell variable name
+    def self.var_name(id, prefix = nil)
+      [
+        prefix,
+        id.gsub(/[^A-Za-z0-9_]/, '_').upcase
+      ].compact.join('_')
+    end
   end
 end

--- a/app/lib/bk/compat/parsers/gha/expressions.rb
+++ b/app/lib/bk/compat/parsers/gha/expressions.rb
@@ -186,6 +186,15 @@ module BK
           "#{path_list} does not appear to be a valid step output"
         end
       end
+
+      def self.replace_context_steps(path)
+        id, action, *_rest = path.split('.', 3)
+        if action == 'outputs'
+          'Step outputs not currently supported'
+        elsif %w[conclussion outcome].include?(action)
+          "$$#{BK::Compat.var_name(id, 'GHA_STEP')}"
+        end
+      end
     end
 
     class GithubExpressions

--- a/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/outputs.yaml.snap
+++ b/app/spec/lib/bk/compat/__snapshots__/examples/github-actions/outputs.yaml.snap
@@ -2,7 +2,9 @@
 steps:
 - commands:
   - echo "test=hello" >> "$GITHUB_OUTPUT"
+  - GHA_STEP_STEP1="$$?"
   - echo "test=world" >> "$GITHUB_OUTPUT"
+  - GHA_STEP_STEP2="$$?"
   - source $GITHUB_OUTPUT
   - buildkite-agent metadata set "job1.output1" "$output1"
   - buildkite-agent metadata set "job1.output2" "$output2"
@@ -18,6 +20,8 @@ steps:
   - OUTPUT2="$(buildkite-agent meta-data get 'job1.output2')"
   - echo "$OUTPUT1 $OUTPUT2"
   - ")"
+  - echo "$$GHA_STEP_STEP1"
+  - echo "$$GHA_STEP_STEP2"
   depends_on:
   - job1
   agents:


### PR DESCRIPTION
If a step has an `id` it is possible that a later job tries to use it so save the exit code to get a `step` status.

Unfortunately, step outputs are only available for `uses` which are being handled in a very ad-hoc way at this time with no outputs whatsoever