### PR TITLE
Refactoring of branch translation

### DIFF
--- a/app/lib/bk/compat/parsers/gha/jobs.rb
+++ b/app/lib/bk/compat/parsers/gha/jobs.rb
@@ -2,7 +2,6 @@
 
 require_relative 'concurrency'
 require_relative 'matrix'
-require_relative 'branches'
 require_relative 'services'
 require_relative 'steps'
 
@@ -13,7 +12,6 @@ module BK
       def parse_job(name, config)
         bk_step = generate_base_step(name, config)
         set_concurrency(bk_step, config) if config['concurrency']
-        set_branch_filters(bk_step, config) if config['workflow_triggers']
         bk_step.matrix = generate_matrix(config['strategy']['matrix']) if config['strategy']
         config['steps'].each { |step| bk_step << translate_step(step) }
         bk_step.agents.update(config.slice('runs-on'))


### PR DESCRIPTION
Simplified the branch translation code.

Made it so that the code is simpler by moving it up one level up in the hierarchy instead of having to copy it to all Job configurations and adding it to the translated step.