### PR TITLE
Refactor concurrency mapping

### DIFF
--- a/app/lib/bk/compat/parsers/gha/jobs.rb
+++ b/app/lib/bk/compat/parsers/gha/jobs.rb
@@ -15,7 +15,6 @@ module BK
         bk_step.matrix = generate_matrix(config['strategy']['matrix']) if config['strategy']
         config['steps'].each { |step| bk_step << translate_step(step) }
         bk_step.agents.update(config.slice('runs-on'))
-        bk_step.depends_on = Array(config['needs'])
         bk_step.conditional = generate_if(config['if']) if config['if']
 
         # these two should be last because they need to execute at the end
@@ -29,7 +28,7 @@ module BK
         BK::Compat::GHAStep.new(
           label: ":github: #{name}",
           key: name,
-          depends_on: config.fetch('needs', []),
+          depends_on: Array(config.fetch('needs', [])),
           env: config.fetch('env', {}),
           timeout_in_minutes: config['timeout-minutes'],
           soft_fail: config['continue-on-error']

--- a/app/lib/bk/compat/parsers/gha/jobs.rb
+++ b/app/lib/bk/compat/parsers/gha/jobs.rb
@@ -11,7 +11,7 @@ module BK
     class GitHubActions
       def parse_job(name, config)
         bk_step = generate_base_step(name, config)
-        set_concurrency(bk_step, config) if config['concurrency']
+        bk_step << translate_concurrency(config['concurrency'])
         bk_step.matrix = generate_matrix(config['strategy']['matrix']) if config['strategy']
         config['steps'].each { |step| bk_step << translate_step(step) }
         bk_step.agents.update(config.slice('runs-on'))

--- a/app/lib/bk/compat/pipeline/step.rb
+++ b/app/lib/bk/compat/pipeline/step.rb
@@ -148,6 +148,8 @@ module BK
         HASH_ATTRIBUTES.each { |a| send(a).merge!(new_step.send(a)) }
 
         @conditional = BK::Compat.xxand(conditional, new_step.conditional)
+        @concurrency = [@concurrency, new_step.concurrency].compact.min
+        @concurrency_group ||= new_step.concurrency_group
 
         # TODO: these could be a hash with exit codes
         @soft_fail = soft_fail || new_step.soft_fail


### PR DESCRIPTION
Uses an intermediate step to mergeback concurrency translations.

This triggered a hidden bug due to setting `depends_on` two different ways so corrected that as well.