### PR TITLE
SUP-1885: `working_directory` for CircleCI jobs and command ordering placement

### DIFF
--- a/app/lib/bk/compat/pipeline/step.rb
+++ b/app/lib/bk/compat/pipeline/step.rb
@@ -141,7 +141,15 @@ module BK
       end
 
       def merge!(new_step)
-        LIST_ATTRIBUTES.each { |a| send(a).concat(new_step.send(a)) }
+ #       puts "new step"
+ #       p new_step.commands
+        LIST_ATTRIBUTES.each { |a| 
+          if a == "commands" && new_step.commands.length == 1 && new_step.commands[0].start_with?("cd")
+            @commands.unshift(new_step.commands[0])
+          else
+            send(a).concat(new_step.send(a))
+          end 
+        }
         HASH_ATTRIBUTES.each { |a| send(a).merge!(new_step.send(a)) }
 
         @conditional = BK::Compat.xxand(conditional, new_step.conditional)

--- a/app/lib/bk/compat/pipeline/step.rb
+++ b/app/lib/bk/compat/pipeline/step.rb
@@ -144,7 +144,7 @@ module BK
  #       puts "new step"
  #       p new_step.commands
         LIST_ATTRIBUTES.each { |a| 
-          if a == "commands" && new_step.commands.length == 1 && new_step.commands[0].start_with?("cd")
+          if a.eql?("commands") && new_step.commands.length > 0 && new_step.commands[0].start_with?("cd")
             @commands.unshift(new_step.commands[0])
           else
             send(a).concat(new_step.send(a))

--- a/app/lib/bk/compat/pipeline/step.rb
+++ b/app/lib/bk/compat/pipeline/step.rb
@@ -157,7 +157,7 @@ module BK
         nil
       end
 
-      def merge_command_attributes(new_step) 
+      def merge_command_attribute(new_step) 
         # If we've generated a new step with cd (working_directory) - unshift it to @commands, otherwise concat as normal
         if new_step.commands.length == 1 && new_step.commands[0].start_with?("cd")
           @commands.unshift(new_step.commands[0])

--- a/app/lib/bk/compat/pipeline/step.rb
+++ b/app/lib/bk/compat/pipeline/step.rb
@@ -141,15 +141,8 @@ module BK
       end
 
       def merge!(new_step)
- #       puts "new step"
- #       p new_step.commands
-        LIST_ATTRIBUTES.each { |a| 
-          if a.eql?("commands") && new_step.commands.length == 1 && new_step.commands[0].start_with?("cd")
-            @commands.unshift(new_step.commands[0])
-          else
-            send(a).concat(new_step.send(a))
-          end 
-        }
+        # Merge list / hash attributes
+        LIST_ATTRIBUTES.each { |a| a.eql?("commands") ? merge_command_attribute(new_step) : send(a).concat(new_step.send(a))}
         HASH_ATTRIBUTES.each { |a| send(a).merge!(new_step.send(a)) }
 
         @conditional = BK::Compat.xxand(conditional, new_step.conditional)
@@ -162,6 +155,15 @@ module BK
         @soft_fail ||= new_step.soft_fail
 
         nil
+      end
+
+      def merge_command_attributes(new_step) 
+        # If we've generated a new step with cd (working_directory) - unshift it to @commands, otherwise concat as normal
+        if new_step.commands.length == 1 && new_step.commands[0].start_with?("cd")
+          @commands.unshift(new_step.commands[0])
+        else
+          @commands.concat(new_step.commands)
+        end
       end
 
       def instance_attributes

--- a/app/lib/bk/compat/pipeline/step.rb
+++ b/app/lib/bk/compat/pipeline/step.rb
@@ -144,7 +144,7 @@ module BK
  #       puts "new step"
  #       p new_step.commands
         LIST_ATTRIBUTES.each { |a| 
-          if a.eql?("commands") && new_step.commands.length > 0 && new_step.commands[0].start_with?("cd")
+          if a.eql?("commands") && new_step.commands.length == 1 && new_step.commands[0].start_with?("cd")
             @commands.unshift(new_step.commands[0])
           else
             send(a).concat(new_step.send(a))

--- a/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/java-maven.yml.snap
+++ b/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/java-maven.yml.snap
@@ -1,11 +1,11 @@
 ---
 steps:
 - commands:
+  - cd ~/project
   - "# No need for checkout, the agent takes care of that"
   - mvn clean install
   - mvn test
   - mvn package
-  - cd ~/project
   plugins:
   - docker#v5.10.0:
       image: circleci/openjdk:11-jdk-buster

--- a/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/parallelism.yml.snap
+++ b/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/parallelism.yml.snap
@@ -1,8 +1,8 @@
 ---
 steps:
 - commands:
-  - go test -v $(go list ./... | circleci tests split)
   - cd ~/my-app
+  - go test -v $(go list ./... | circleci tests split)
   plugins:
   - docker#v5.10.0:
       image: cimg/base:2022.09

--- a/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/parameters-top-level.yml.snap
+++ b/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/parameters-top-level.yml.snap
@@ -1,9 +1,9 @@
 ---
 steps:
 - commands:
+  - cd << pipeline.parameters.workingdir >>
   - echo "Image tag used was ${IMAGETAG}"
   - echo "$(pwd) == << pipeline.parameters.workingdir >>"
-  - cd << pipeline.parameters.workingdir >>
   plugins:
   - docker#v5.10.0:
       image: ubuntu:latest

--- a/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/segmentio-aws-okta.yml.snap
+++ b/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/segmentio-aws-okta.yml.snap
@@ -1,6 +1,7 @@
 ---
 steps:
 - commands:
+  - cd /go/src/github.com/segmentio/aws-okta
   - "# No need for checkout, the agent takes care of that"
   - echo '~~~ Install linux dependencies - libusb'
   - sudo apt update -q
@@ -17,7 +18,6 @@ steps:
   - "  git status"
   - "  exit 1"
   - fi
-  - cd /go/src/github.com/segmentio/aws-okta
   plugins:
   - docker#v5.10.0:
       image: circleci/golang:1.13
@@ -39,6 +39,7 @@ steps:
     executor_type: docker
   key: test-build-golang-prev
 - commands:
+  - cd /go/src/github.com/segmentio/aws-okta
   - "# No need for checkout, the agent takes care of that"
   - echo '~~~ Install nfpm, rpmbuild'
   - sudo make -f Makefile.tools nfpm-debian rpmbuild-debian
@@ -50,7 +51,6 @@ steps:
   - cd .
   - buildkite-agent artifact upload 'dist/*'
   - cd -
-  - cd /go/src/github.com/segmentio/aws-okta
   plugins:
   - docker#v5.10.0:
       image: circleci/golang:1.13
@@ -58,6 +58,7 @@ steps:
     executor_type: docker
   key: dist-linux
 - commands:
+  - cd /go/src/github.com/segmentio/aws-okta
   - "# No need for checkout, the agent takes care of that"
   - "# :circleci: attach_workspace "
   - if [ ! -d '.' ]; then mkdir '.'; fi
@@ -72,7 +73,6 @@ steps:
   - sudo gem install rake
   - sudo make -f Makefile.tools package_cloud
   - make -f Makefile.release publish-packagecloud
-  - cd /go/src/github.com/segmentio/aws-okta
   depends_on:
   - dist-linux
   plugins:
@@ -82,6 +82,7 @@ steps:
     executor_type: docker
   key: publish-packagecloud
 - commands:
+  - cd /go/src/github.com/segmentio/aws-okta
   - "# No need for checkout, the agent takes care of that"
   - "# :circleci: attach_workspace "
   - if [ ! -d '.' ]; then mkdir '.'; fi
@@ -90,7 +91,6 @@ steps:
   - echo '~~~ Install tools'
   - make -f Makefile.tools github-release
   - make -f Makefile.release publish-github-linux
-  - cd /go/src/github.com/segmentio/aws-okta
   depends_on:
   - dist-linux
   plugins:


### PR DESCRIPTION
Fixed the ordering of parsing working directory (`cd`) step generation and merging.

Essentially we parse the generated steps through `LIST_ATTRIBUTES` - which includes the `commands` key. Upon generation of this step via `parse_executor`, we [merge](https://github.com/buildkite/migration/blob/main/app/lib/bk/compat/parsers/circleci/jobs.rb#L29-L34) (`<<`) this created step the `bk_step` - the latter of which is generated first by `parse_command`.

With the merge, the commands are added at the _end_ of the commands list - this corrects it by determining if we've generated a step with a commands list of size 1, and starts with `cd`- for which is unshifted to the start of the list. Else - we concat the steps as per normal.