### PR TITLE
SUP-2097: `after-script` translation

### DIFF
--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -29,7 +29,7 @@ module BK
             agents: translate_agents(step.slice('size', 'runs-on'))
           ).tap do |cmd|
             cmd.timeout_in_minutes = step.fetch('max-time', nil)
-            cmd.add_commands('# The after-script property should be configured as a pre-exit repository hook') if !step['after-script'].nil?
+            translate_after_script(cmd) if !step['after-script'].nil?
           end
         end
 
@@ -53,6 +53,10 @@ module BK
               "# Invalid script element #{s}"
             end
           end
+        end
+
+        def translate_after_script(cmd)
+          cmd.add_commands('# The after-script property should be configured as a pre-exit repository hook')
         end
       end
     end

--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -42,9 +42,10 @@ module BK
             agents: translate_agents(step.slice('size', 'runs-on'))
           ).tap do |cmd|
             cmd.timeout_in_minutes = step.fetch('max-time', nil)
-            translate_after_script(cmd) if !step['after-script'].nil?
             # Specify image if it was defined on the step
             cmd << translate_image(step['image']) if step.include?('image')
+            # Translate after-script
+            cmd.add_commands('# The after-script property should be configured as a pre-exit repository hook') if !step['after-script'].nil?
           end
         end
 
@@ -77,10 +78,6 @@ module BK
               "# Invalid script element #{s}"
             end
           end
-        end
-
-        def translate_after_script(cmd)
-          cmd.add_commands('# The after-script property should be configured as a pre-exit repository hook')
         end
       end
     end

--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -29,6 +29,7 @@ module BK
             agents: translate_agents(step.slice('size', 'runs-on'))
           ).tap do |cmd|
             cmd.timeout_in_minutes = step.fetch('max-time', nil)
+            cmd.add_commands('# The after-script property should be configured as a pre-exit repository hook') if !step['after-script'].nil?
           end
         end
 

--- a/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/after-script.yml.snap
+++ b/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/after-script.yml.snap
@@ -1,0 +1,7 @@
+---
+steps:
+- commands:
+  - npm install
+  - npm test
+  - "# The after-script property should be configured as a pre-exit repository hook"
+  label: Build and test

--- a/app/spec/lib/bk/compat/bitbucket/examples/after-script.yml
+++ b/app/spec/lib/bk/compat/bitbucket/examples/after-script.yml
@@ -1,0 +1,9 @@
+pipelines:
+  default:
+    - step:
+        name: Build and test
+        script:
+          - npm install
+          - npm test
+        after-script:
+          - echo "after script has run!"


### PR DESCRIPTION
Translating the `after-script` property of `step`s: which are equivalent to pre-exit hooks; and specifically repository located hooks.