### PR TITLE
SUP-2102: `fail-fast` translation

### DIFF
--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -44,6 +44,7 @@ module BK
             cmd.timeout_in_minutes = step.fetch('max-time', nil)
             # Specify image if it was defined on the step
             cmd << translate_image(step['image']) if step.include?('image')
+            cmd.add_commands('# `fail-fast` has no direct translation - consider using `soft_fail`/`cancel_on_build_failing`.') if step.include?('fail-fast')
           end
         end
 

--- a/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/fail-fast.yml.snap
+++ b/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/fail-fast.yml.snap
@@ -1,0 +1,10 @@
+---
+steps:
+- commands:
+  - npm install
+  - npm test
+  - "# `fail-fast` has no direct translation - consider using `soft_fail`/`cancel_on_build_failing`."
+  plugins:
+  - docker#v5.10.0:
+      image: node:21-alpine
+  label: Build and test

--- a/app/spec/lib/bk/compat/bitbucket/examples/fail-fast.yml
+++ b/app/spec/lib/bk/compat/bitbucket/examples/fail-fast.yml
@@ -1,0 +1,10 @@
+pipelines:
+  default:
+    - step:
+        name: Build and test
+        image: node:21-alpine
+        script:
+          - npm install
+          - npm test
+        fail-fast: true
+


### PR DESCRIPTION
Translation of `fail-fast` attributes. Right now there isn't a 1:1 mapping of properties for `command` steps that equate to the given functionality: a combination of `soft_fail` or `cancel_on_build_failing` will allow for similar behaviour from Bitbucket Pipelines.