### PR TITLE
SUP-2101: `deployment` translation

### DIFF
--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -44,6 +44,7 @@ module BK
             cmd.timeout_in_minutes = step.fetch('max-time', nil)
             # Specify image if it was defined on the step
             cmd << translate_image(step['image']) if step.include?('image')
+            cmd.add_commands('# `deployments` has no direct translation.') if step.include?('deployment')
           end
         end
 

--- a/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/deployment.yml.snap
+++ b/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/deployment.yml.snap
@@ -1,0 +1,6 @@
+---
+steps:
+- commands:
+  - python deploy.py prod_env_1
+  - "# `deployments` has no direct translation."
+  label: Deploy to production

--- a/app/spec/lib/bk/compat/bitbucket/examples/deployment.yml
+++ b/app/spec/lib/bk/compat/bitbucket/examples/deployment.yml
@@ -1,0 +1,7 @@
+pipelines:
+  default:
+    - step:
+        name: Deploy to production
+        deployment: production env 1
+        script:
+          - python deploy.py prod_env_1


### PR DESCRIPTION
Translation of `deployment` attribute. Right now there isn't a 1:1 mapping as a Deployment is a dashboard on the Bitbucket Pipelines side that doesn't translate to any specific Buildkite `command` step property