### PR TITLE
SUP-2109: `oidc` translation 

### DIFF
--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -44,6 +44,7 @@ module BK
             cmd.timeout_in_minutes = step.fetch('max-time', nil)
             # Specify image if it was defined on the step
             cmd << translate_image(step['image']) if step.include?('image')
+            cmd << translate_oidc if step['oidc']
           end
         end
 
@@ -52,6 +53,15 @@ module BK
             name: 'docker',
             config: {
               'image' => "#{image}"
+            }
+          )
+        end
+
+        def translate_oidc()
+          BK::Compat::Plugin.new(
+            name: 'aws-assume-role-with-web-identity',
+            config: {
+              'role-arn' => "arn:aws:iam::AWS-ACCOUNT-ID:role/SOME-ROLE"
             }
           )
         end

--- a/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/oidc.yaml.snap
+++ b/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/oidc.yaml.snap
@@ -1,0 +1,11 @@
+---
+steps:
+- commands:
+  - echo "I can access data through OpenID Connect!"
+  - aws sts assume-role-with-web-identity --role-arn arn:aws:iam::XXXXXX:role/projectx-build
+    --role-session-name build-session  --web-identity-token "$BITBUCKET_STEP_OIDC_TOKEN"
+    --duration-seconds 1000
+  plugins:
+  - aws-assume-role-with-web-identity:
+      role-arn: arn:aws:iam::AWS-ACCOUNT-ID:role/SOME-ROLE
+  label: Script step

--- a/app/spec/lib/bk/compat/bitbucket/examples/oidc.yaml
+++ b/app/spec/lib/bk/compat/bitbucket/examples/oidc.yaml
@@ -1,0 +1,7 @@
+pipelines:
+  default:
+    - step:
+        oidc: true
+        script:
+          - echo "I can access data through OpenID Connect!"
+          - aws sts assume-role-with-web-identity --role-arn arn:aws:iam::XXXXXX:role/projectx-build --role-session-name build-session  --web-identity-token "$BITBUCKET_STEP_OIDC_TOKEN" --duration-seconds 1000


### PR DESCRIPTION
`oidc` parameter translation. Translates to our `aws-assume-role-with-web-identity` plugin, though the IAM role that is needed by the plugin can be specified in various areas (i.e via a flag calling `aws sts assume-role-with-web-identity`, or via an `AWS_ROLE_ARN` exported variable in the `step`'s `script`