### PR TITLE
Global clone option

### DIFF
--- a/app/lib/bk/compat/parsers/bitbucket.rb
+++ b/app/lib/bk/compat/parsers/bitbucket.rb
@@ -41,7 +41,7 @@ module BK
       def parse
         # custom is also valid, but not supported just yet
         pps = %w[branches default pull-requests tags].freeze
-        defaults = @config.slice('image')
+        defaults = @config.slice('image', 'clone')
         conf = @config['pipelines']
         Pipeline.new(
           steps: pps.map { |p| parse_pipeline(conf[p], defaults) if conf.include?(p) }.compact

--- a/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/global-clone.yml.snap
+++ b/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/global-clone.yml.snap
@@ -1,0 +1,28 @@
+---
+steps:
+- group: "~"
+  key: group1
+  steps:
+  - commands:
+    - echo 'simple'
+    - "# repository interactions (clone options) should be configured in the agent
+      itself"
+    plugins:
+    - sparse-checkout:
+        paths:
+        - path1/*
+        - path2
+        no-cone: false
+    label: simple
+  - commands:
+    - echo 'no cloning'
+    - "# repository interactions (clone options) should be configured in the agent
+      itself"
+    env:
+      BUILKITE_REPO: ''
+    label: no clone
+  - commands:
+    - echo 'no sparse'
+    - "# repository interactions (clone options) should be configured in the agent
+      itself"
+    label: no sparse

--- a/app/spec/lib/bk/compat/bitbucket/examples/global-clone.yml
+++ b/app/spec/lib/bk/compat/bitbucket/examples/global-clone.yml
@@ -1,0 +1,25 @@
+clone:
+  sparse-checkout:
+    patterns:
+      - path1/*
+      - path2
+
+pipelines:
+  default:
+    - step:
+        name: simple
+        script:
+          - echo 'simple'
+    - step:
+        name: no clone
+        clone:
+          enabled: false
+        script:
+          - echo 'no cloning'
+    - step:
+        name: no sparse
+        clone:
+          sparse-checkout:
+            enabled: false
+        script:
+          - echo 'no sparse'


### PR DESCRIPTION
Adds `clone` to the list of defaults to use and an example to ensure it is correctly merged down to individual steps