### PR TITLE
Translator registration defs per parser

### DIFF
--- a/app/lib/bk/compat/parsers/bitbucket.rb
+++ b/app/lib/bk/compat/parsers/bitbucket.rb
@@ -42,8 +42,6 @@ module BK
       end
 
       def parse
-        p @config
-        s = @config.slice('image', 'clone')]
         defaults = @config.slice('image', 'clone').merge(@config.fetch('options', {}))
         conf = @config['pipelines']
 
@@ -59,8 +57,8 @@ module BK
       def register_translators
         BK::Compat::BitBucketSteps::Import.new(register: method(:register_translator))
         BK::Compat::BitBucketSteps::Parallel.new(register: method(:register_translator), recursor: method(:translate_step))
-        BK::Compat::BitBucketSteps::Stages.new(register: method(:register_translator),recursor: method(:translate_step))
-        BK::Compat::BitBucketSteps::Step.new(register: method(:register_translator),definitions: @config.fetch('definitions', {}))
+        BK::Compat::BitBucketSteps::Stages.new(register: method(:register_translator), recursor: method(:translate_step))
+        BK::Compat::BitBucketSteps::Step.new(register: method(:register_translator), definitions: @config.fetch('definitions', {}))
         BK::Compat::BitBucketSteps::Variables.new(register: method(:register_translator))
       end
 

--- a/app/lib/bk/compat/parsers/bitbucket.rb
+++ b/app/lib/bk/compat/parsers/bitbucket.rb
@@ -38,7 +38,7 @@ module BK
         @config = YAML.safe_load(text, aliases: true)
         @options = options
 
-        register_translators
+        register_translators!
       end
 
       def parse
@@ -54,11 +54,20 @@ module BK
 
       private
 
-      def register_translators
+      def register_translators!
         BK::Compat::BitBucketSteps::Import.new(register: method(:register_translator))
-        BK::Compat::BitBucketSteps::Parallel.new(register: method(:register_translator), recursor: method(:translate_step))
-        BK::Compat::BitBucketSteps::Stages.new(register: method(:register_translator), recursor: method(:translate_step))
-        BK::Compat::BitBucketSteps::Step.new(register: method(:register_translator), definitions: @config.fetch('definitions', {}))
+        BK::Compat::BitBucketSteps::Parallel.new(
+          register: method(:register_translator),
+          recursor: method(:translate_step)
+        )
+        BK::Compat::BitBucketSteps::Stages.new(
+          register: method(:register_translator),
+          recursor: method(:translate_step)
+        )
+        BK::Compat::BitBucketSteps::Step.new(
+          register: method(:register_translator),
+          definitions: @config.fetch('definitions', {})
+        )
         BK::Compat::BitBucketSteps::Variables.new(register: method(:register_translator))
       end
 

--- a/app/lib/bk/compat/parsers/bitbucket.rb
+++ b/app/lib/bk/compat/parsers/bitbucket.rb
@@ -38,23 +38,12 @@ module BK
         @config = YAML.safe_load(text, aliases: true)
         @options = options
 
-        BK::Compat::BitBucketSteps::Import.new(register: method(:register_translator))
-        BK::Compat::BitBucketSteps::Parallel.new(
-          register: method(:register_translator),
-          recursor: method(:translate_step)
-        )
-        BK::Compat::BitBucketSteps::Stages.new(
-          register: method(:register_translator),
-          recursor: method(:translate_step)
-        )
-        BK::Compat::BitBucketSteps::Step.new(
-          register: method(:register_translator),
-          definitions: @config.fetch('definitions', {})
-        )
-        BK::Compat::BitBucketSteps::Variables.new(register: method(:register_translator))
+        register_translators
       end
 
       def parse
+        p @config
+        s = @config.slice('image', 'clone')]
         defaults = @config.slice('image', 'clone').merge(@config.fetch('options', {}))
         conf = @config['pipelines']
 
@@ -66,6 +55,14 @@ module BK
       end
 
       private
+
+      def register_translators
+        BK::Compat::BitBucketSteps::Import.new(register: method(:register_translator))
+        BK::Compat::BitBucketSteps::Parallel.new(register: method(:register_translator), recursor: method(:translate_step))
+        BK::Compat::BitBucketSteps::Stages.new(register: method(:register_translator),recursor: method(:translate_step))
+        BK::Compat::BitBucketSteps::Step.new(register: method(:register_translator),definitions: @config.fetch('definitions', {}))
+        BK::Compat::BitBucketSteps::Variables.new(register: method(:register_translator))
+      end
 
       def non_default_pipelines(defaults)
         pps = %w[branches custom pull-requests tags].freeze

--- a/app/lib/bk/compat/parsers/circleci.rb
+++ b/app/lib/bk/compat/parsers/circleci.rb
@@ -45,7 +45,7 @@ module BK
         @commands_by_key = {}
         @executors = {}
 
-        register_translators
+        register_translators!
       end
 
       def parse
@@ -62,8 +62,11 @@ module BK
 
       private
 
-      def register_translators
-        BK::Compat::CircleCISteps::Builtins.new(register: method(:register_translator), recursor: method(:translate_steps))
+      def register_translators!
+        BK::Compat::CircleCISteps::Builtins.new(
+          register: method(:register_translator),
+          recursor: method(:translate_steps)
+        )     
       end
 
       def load_elements!

--- a/app/lib/bk/compat/parsers/circleci.rb
+++ b/app/lib/bk/compat/parsers/circleci.rb
@@ -45,10 +45,7 @@ module BK
         @commands_by_key = {}
         @executors = {}
 
-        BK::Compat::CircleCISteps::Builtins.new(
-          register: method(:register_translator),
-          recursor: method(:translate_steps)
-        )
+        register_translators
       end
 
       def parse
@@ -64,6 +61,10 @@ module BK
       end
 
       private
+
+      def register_translators
+        BK::Compat::CircleCISteps::Builtins.new(register: method(:register_translator), recursor: method(:translate_steps))
+      end
 
       def load_elements!
         # order is important

--- a/app/lib/bk/compat/parsers/gha.rb
+++ b/app/lib/bk/compat/parsers/gha.rb
@@ -35,8 +35,7 @@ module BK
         @config = YAML.safe_load(text)
         @options = options
 
-        GHABuiltins.new(register: method(:register_translator))
-        GHAActions.new(register: method(:register_translator))
+        register_translators
       end
 
       def parse
@@ -57,6 +56,13 @@ module BK
           steps: steps,
           env: @config.fetch('env', {})
         )
+      end
+
+      private
+      
+      def register_translators
+        GHABuiltins.new(register: method(:register_translator))
+        GHAActions.new(register: method(:register_translator))
       end
     end
   end

--- a/app/lib/bk/compat/parsers/gha.rb
+++ b/app/lib/bk/compat/parsers/gha.rb
@@ -35,7 +35,7 @@ module BK
         @config = YAML.safe_load(text)
         @options = options
 
-        register_translators
+        register_translators!
       end
 
       def parse
@@ -60,7 +60,7 @@ module BK
 
       private
       
-      def register_translators
+      def register_translators!
         GHABuiltins.new(register: method(:register_translator))
         GHAActions.new(register: method(:register_translator))
       end

--- a/app/lib/bk/compat/parsers/harness.rb
+++ b/app/lib/bk/compat/parsers/harness.rb
@@ -57,7 +57,7 @@ module BK
 
       def register_translators
         BK::Compat::HarnessSteps::Run.new(register: method(:register_translator))
-      end
+      end      
 
       def simplify_group(group)
         # If there ended up being only 1 stage, skip the group and just

--- a/app/lib/bk/compat/parsers/harness.rb
+++ b/app/lib/bk/compat/parsers/harness.rb
@@ -36,7 +36,7 @@ module BK
         @config = YAML.safe_load(text, aliases: true)
         @options = options
 
-        register_translators
+        register_translators!
       end
 
       def parse
@@ -55,7 +55,7 @@ module BK
 
       private
 
-      def register_translators
+      def register_translators!
         BK::Compat::HarnessSteps::Run.new(register: method(:register_translator))
       end      
 

--- a/app/lib/bk/compat/parsers/harness.rb
+++ b/app/lib/bk/compat/parsers/harness.rb
@@ -36,7 +36,7 @@ module BK
         @config = YAML.safe_load(text, aliases: true)
         @options = options
 
-        BK::Compat::HarnessSteps::Run.new(register: method(:register_translator))
+        register_translators
       end
 
       def parse
@@ -54,6 +54,10 @@ module BK
       end
 
       private
+
+      def register_translators
+        BK::Compat::HarnessSteps::Run.new(register: method(:register_translator))
+      end
 
       def simplify_group(group)
         # If there ended up being only 1 stage, skip the group and just


### PR DESCRIPTION
We've got quite a few translators matching specific methods that are used within each pipeline parser - namely that of `translate_step` thats shared between all parsers currently.

Split out each parser's translator registration into its own `register_translators` def (privated) which are loaded on each class's `initialize`/creation. 