### PR TITLE
Added `depends_on` to GroupStep class, variables example switched to `custom` starting condition

### DIFF
--- a/app/lib/bk/compat/pipeline/step.rb
+++ b/app/lib/bk/compat/pipeline/step.rb
@@ -206,17 +206,19 @@ module BK
 
     # group step
     class GroupStep
-      attr_accessor :label, :key, :steps, :conditional
+      attr_accessor :label, :key, :steps, :depends_on, :conditional
 
-      def initialize(label: '~', key: nil, steps: [], conditional: nil)
+      def initialize(label: '~', key: nil, steps: [], depends_on: [], conditional: nil)
         @label = label
         @key = key
+        @depends_on = depends_on
         @steps = steps
         @conditional = conditional
       end
 
       def to_h
         { group: @label, key: @key, steps: @steps.map(&:to_h) }.tap do |h|
+          h[:depends_on] = @depends_on unless @depends_on.empty?
           h[:if] = @conditional unless @conditional.nil?
         end.compact
       end

--- a/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/variables.yml.snap
+++ b/app/spec/lib/bk/compat/bitbucket/__snapshots__/spec/lib/bk/compat/bitbucket/examples/variables.yml.snap
@@ -1,6 +1,9 @@
 ---
 steps:
-- group: default
+- key: execute-34fda39a698739f93a76af1583cf0b9e937f3561
+  prompt: Execute step 34fda39a698739f93a76af1583cf0b9e937f3561?
+  input: execute-34fda39a698739f93a76af1583cf0b9e937f3561
+- group: deployer
   steps:
   - key: custom-vars
     fields:
@@ -23,3 +26,5 @@ steps:
   - commands:
     - echo "$Username manually triggered for a build for $Region as $Role!"
     label: Script step
+  depends_on:
+  - execute-34fda39a698739f93a76af1583cf0b9e937f3561

--- a/app/spec/lib/bk/compat/bitbucket/examples/variables.yml
+++ b/app/spec/lib/bk/compat/bitbucket/examples/variables.yml
@@ -1,18 +1,19 @@
 # from https://support.atlassian.com/bitbucket-cloud/docs/pipeline-start-conditions/#Example-%E2%80%94-using-the-variables-property-to-define-custom-pipeline-variables
 
 pipelines:
-  default:
-    - variables:
-        - name: Username
-        - name: Role
-          default: "admin"          # optionally provide a default variable value
-          description: "Add user role"
-        - name: Region
-          default: "us-east-1"
-          allowed-values:           # optionally restrict variable values
-            - "ap-southeast-2"
-            - "us-east-1"
-            - "us-west-2"
-    - step:
-        script:
-          - echo "$Username manually triggered for a build for $Region as $Role!"
+  custom:
+    deployer: # The name that is displayed in the list in the Bitbucket Cloud GUI
+      - variables:
+          - name: Username
+          - name: Role
+            default: "admin"          # optionally provide a default variable value
+            description: "Add user role"
+          - name: Region
+            default: "us-east-1"
+            allowed-values:           # optionally restrict variable values
+              - "ap-southeast-2"
+              - "us-east-1"
+              - "us-west-2"
+      - step:
+          script:
+            - echo "$Username manually triggered for a build for $Region as $Role!"


### PR DESCRIPTION
Some adjustments in this PR for Group Steps + custom BB pipelines alterations with variables
- Added the `depends_on` attribute to the `GroupStep` class (get/set) as its a supported attribute within said step [type](https://buildkite.com/docs/pipelines/group-step)
- For the `variables.yml` example for Bitbucket pipelines - this _was_ using the `default` starting condition. According to the [schema](https://bitbucket.org/atlassianlabs/intellij-bitbucket-references-plugin/raw/master/src/main/resources/schemas/bitbucket-pipelines.schema.json), only `custom` starting condition pipelines can have the `variables` property defined (`custom_pipeline` component with either `item_with_variables` or `import_pipeline` respectfully). Altered this example to specifically use a `custom` starting condition - which brings on input step dependencies from bullet-point 1 ☝️ 