### PR TITLE
Translator refactoring

### DIFF
--- a/app/lib/bk/compat/parsers/bitbucket/import.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/import.rb
@@ -7,15 +7,6 @@ module BK
     module BitBucketSteps
       # Implementation of native step translation
       class Import
-        def initialize(register:)
-          register.call(
-            method(:matcher),
-            method(:translator)
-          )
-        end
-
-        private
-
         def matcher(conf, *, **)
           conf.include?('import')
         end

--- a/app/lib/bk/compat/parsers/bitbucket/parallel.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/parallel.rb
@@ -7,16 +7,6 @@ module BK
     module BitBucketSteps
       # Implementation of stage translation
       class Parallel
-        def initialize(register:, recursor: nil)
-          @recursor = recursor # to call back to translate steps further
-          register.call(
-            method(:matcher),
-            method(:translator)
-          )
-        end
-
-        private
-
         def matcher(conf, *, **)
           conf.include?('parallel')
         end
@@ -28,7 +18,7 @@ module BK
           # may be a good idea when/if fail-fast is properly supported
           # defaults['fail-fast'] = parallel['fail-fast']
 
-          steps = Array(parallel['steps']).map { |s| @recursor&.call(s, defaults: defaults) }
+          steps = Array(parallel['steps']).map { |s| recursor(s, defaults: defaults) }
           # by default steps will have Wait inbetween
           steps = steps.flatten.reject { |s| s.is_a?(WaitStep) }
           BK::Compat::GroupStep.new(

--- a/app/lib/bk/compat/parsers/bitbucket/stages.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/stages.rb
@@ -7,16 +7,6 @@ module BK
     module BitBucketSteps
       # Implementation of stage translation
       class Stages
-        def initialize(register:, recursor: nil)
-          @recursor = recursor # to call back to translate steps further
-          register.call(
-            method(:matcher),
-            method(:translator)
-          )
-        end
-
-        private
-
         def matcher(conf, *, **)
           conf.include?('stage')
         end
@@ -33,9 +23,11 @@ module BK
           )
         end
 
+        private
+
         def translate_steps(stage, defaults)
           # TODO: these steps can not have conditions
-          steps = Array(stage['steps']).map { |s| @recursor&.call(s, defaults: defaults) }
+          steps = Array(stage['steps']).map { |s| recursor(s, defaults: defaults) }
           steps = BK::Compat::BitBucket.translate_trigger(stage['trigger'], steps.flatten)
           steps.pop if steps.last.is_a?(BK::Compat::WaitStep)
           steps

--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -13,17 +13,10 @@ module BK
     module BitBucketSteps
       # Implementation of native step translation
       class Step
-        def initialize(register:, definitions: {})
+        def initialize(definitions: {})
           load_caches!(definitions.fetch('caches', nil))
           load_services!(definitions.fetch('services', nil))
-
-          register.call(
-            method(:matcher),
-            method(:translator)
-          )
         end
-
-        private
 
         def matcher(conf, *, **)
           conf.include?('step')
@@ -34,6 +27,8 @@ module BK
 
           BK::Compat::BitBucket.translate_trigger(conf['step'].fetch('trigger', 'automatic'), base)
         end
+
+        private
 
         def base_step(step)
           cmd = BK::Compat::CommandStep.new(

--- a/app/lib/bk/compat/parsers/bitbucket/variables.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/variables.rb
@@ -8,15 +8,6 @@ module BK
     module BitBucketSteps
       # Implementation of native step translation
       class Variables
-        def initialize(register:)
-          register.call(
-            method(:matcher),
-            method(:translator)
-          )
-        end
-
-        private
-
         def matcher(conf, *, **)
           conf.include?('variables')
         end

--- a/app/lib/bk/compat/parsers/circleci.rb
+++ b/app/lib/bk/compat/parsers/circleci.rb
@@ -12,7 +12,6 @@ module BK
   module Compat
     # CircleCI translation scaffolding
     class CircleCI
-      include StepTranslator
       require 'yaml'
 
       def self.name
@@ -63,10 +62,10 @@ module BK
       private
 
       def register_translators!
-        BK::Compat::CircleCISteps::Builtins.new(
-          register: method(:register_translator),
-          recursor: method(:translate_steps)
-        )     
+        @translator = BK::Compat::StepTranslator.new
+        @translator.register(
+          BK::Compat::CircleCISteps::Builtins.new
+        )
       end
 
       def load_elements!

--- a/app/lib/bk/compat/parsers/circleci/jobs.rb
+++ b/app/lib/bk/compat/parsers/circleci/jobs.rb
@@ -49,7 +49,7 @@ module BK
 
         step_list.map do |circle_step|
           key, config = string_or_key(circle_step)
-          @commands_by_key[key]&.instantiate(config) || translate_step(key, config)
+          @commands_by_key[key]&.instantiate(config) || @translator.translate_step(key, config)
         end
       end
     end

--- a/app/lib/bk/compat/parsers/circleci/orbs.rb
+++ b/app/lib/bk/compat/parsers/circleci/orbs.rb
@@ -7,22 +7,20 @@ module BK
       private
 
       def load_orb(key, _conf)
-        CircleCISteps::GenericOrb.new(key, register: method(:register_translator))
+        @translator.register(CircleCISteps::GenericOrb.new(key))
       end
     end
 
     module CircleCISteps
       # Generic orb steps/jobs (that states it is not supported)
       class GenericOrb
-        def initialize(key, register:)
+        def initialize(key)
           @prefix = key
-          register.call(
-            ->(orb, _conf) { orb.start_with?("#{key}/") },
-            method(:translator)
-          )
         end
 
-        private
+        def matcher(orb, _conf)
+          orb.start_with?("#{@prefix}/")
+        end
 
         def translator(action, _config)
           [

--- a/app/lib/bk/compat/parsers/gha.rb
+++ b/app/lib/bk/compat/parsers/gha.rb
@@ -12,7 +12,6 @@ module BK
   module Compat
     # GitHub Actions converter
     class GitHubActions
-      include StepTranslator
       require 'yaml'
 
       def self.name
@@ -59,10 +58,14 @@ module BK
       end
 
       private
-      
+
       def register_translators!
-        GHABuiltins.new(register: method(:register_translator))
-        GHAActions.new(register: method(:register_translator))
+        @translator = BK::Compat::StepTranslator.new
+
+        @translator.register(
+          GHABuiltins.new,
+          GHAActions.new
+        )
       end
     end
   end

--- a/app/lib/bk/compat/parsers/gha/jobs.rb
+++ b/app/lib/bk/compat/parsers/gha/jobs.rb
@@ -13,7 +13,7 @@ module BK
         bk_step = generate_base_step(name, config)
         bk_step << translate_concurrency(config['concurrency'])
         bk_step.matrix = generate_matrix(config['strategy']&.fetch('matrix'))
-        config['steps'].each { |step| bk_step << translate_step(step) }
+        config['steps'].each { |step| bk_step << @translator.translate_step(step) }
         bk_step.agents.update(config.slice('runs-on'))
         bk_step.conditional = generate_if(config['if'])
 

--- a/app/lib/bk/compat/parsers/gha/steps.rb
+++ b/app/lib/bk/compat/parsers/gha/steps.rb
@@ -6,16 +6,11 @@ module BK
   module Compat
     # Implement GHA Builtin Steps
     class GHABuiltins
-      def initialize(register:)
-        register.call(
-          ->(conf) { conf.include?('run') },
-          method(:translate_run)
-        )
+      def matcher(conf)
+        conf.include?('run')
       end
 
-      private
-
-      def translate_run(step)
+      def translator(step)
         [
           step.include?('name') ? "echo '~~~ #{step['name']}'" : nil,
           step.include?('shell') ? '# Shell is determined in the agent' : nil,
@@ -28,6 +23,8 @@ module BK
           )
         ].flatten.compact
       end
+
+      private
 
       def generate_command_string(commands: [], env: {}, workdir: nil, id: nil)
         vars = env.map { |k, v| "#{k}=\"#{v}\"" }

--- a/app/lib/bk/compat/parsers/gha/steps/actions.rb
+++ b/app/lib/bk/compat/parsers/gha/steps/actions.rb
@@ -4,14 +4,11 @@ module BK
   module Compat
     # Implement GHA actions
     class GHAActions
-      def initialize(register:)
-        register.call(
-          ->(conf) { conf.include?('uses') },
-          method(:translate_uses)
-        )
+      def matcher(conf)
+        conf.include?('uses')
       end
 
-      def translate_uses(step)
+      def translator(step)
         root, version = step['uses'].split('@')
 
         # make the action a valid function name

--- a/app/lib/bk/compat/parsers/harness/steps/run.rb
+++ b/app/lib/bk/compat/parsers/harness/steps/run.rb
@@ -7,15 +7,6 @@ module BK
     module HarnessSteps
       # Implementation of native step translation
       class Run
-        def initialize(register:)
-          register.call(
-            method(:matcher),
-            method(:translator)
-          )
-        end
-
-        private
-
         def matcher(type:, **)
           type == 'Run'
         end
@@ -24,7 +15,7 @@ module BK
           BK::Compat::CommandStep.new(
             label: name,
             key: identifier,
-            commands: [ spec['command'] ]
+            commands: [spec['command']]
           )
         end
       end

--- a/app/lib/bk/compat/translator.rb
+++ b/app/lib/bk/compat/translator.rb
@@ -3,7 +3,11 @@
 module BK
   module Compat
     # Dispatch pattern for step translation
-    module StepTranslator
+    class StepTranslator
+      def initialize(default: nil)
+        @default_func = default.nil? ? method(:default_value) : default
+      end
+
       def register_translator(matcher, function)
         @translators ||= [] # utilize an instance variable that may not exist
 
@@ -19,11 +23,16 @@ module BK
         simplify_result(result.flatten, *, **)
       end
 
-      def simplify_result(result_list, *args, **kwargs)
-        return [" # step #{args} #{kwargs} not implemented yet :("] if result_list.empty?
+      def simplify_result(result_list, *, **)
+        return @default_func.call(*, **) if result_list.empty?
 
         result_list = result_list.first if result_list.one?
         result_list
+      end
+
+      def default_value(*args, **kwargs)
+        # Default implementation when the translator doesn't know what to do
+        [" # step #{args} #{kwargs} not implemented yet :("]
       end
     end
   end

--- a/app/lib/bk/compat/translator.rb
+++ b/app/lib/bk/compat/translator.rb
@@ -11,14 +11,14 @@ module BK
 
       def register(*translators)
         translators.each do |tr|
+          # allow translator to have a `recursor` function available
           tr.define_singleton_method(:recursor, method(:translate_step).to_proc)
           @translators << tr
         end
       end
 
       def translate_step(*, **)
-        @translators ||= [] # utilize an instance variable that may not exist
-
+        # we assume each translator has a matcher and a translator method
         result = @translators.select { |translator| translator.matcher(*, **) }
                              .map { |translator| translator.translator(*, **) }
 


### PR DESCRIPTION
The translation Mixin approach made the registration quite cumbersome and convoluted so I changed it from a module to a class to be instantiated. This would also allow to have multiple translators available per class in the future if/when necessary.

