### PR TITLE
Stricter linter

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -3,7 +3,7 @@ steps:
   - label: ":hammer: Linting"
     command:
       - cd app && bundle install
-      - rubocop -l
+      - rubocop
     plugins:
       - docker#v5.10.0:
           image: ruby:3.3.1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: ":hammer: Linting"
     command:
       - cd app && bundle install
-      - rubocop -l
+      - rubocop
     plugins:
       - docker#v5.10.0:
           image: ruby:3.3.1

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.rb]
+indent_style = space
+indent_size = 2

--- a/app/.rubocop.yml
+++ b/app/.rubocop.yml
@@ -8,6 +8,11 @@ Style/HashSyntax:
 Naming/BlockForwarding:
   EnforcedStyle: explicit
 
+# TODO: solve this
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*.rb
+
 Metrics/MethodLength:
   CountAsOne: [ 'array', 'hash', 'heredoc' ]
 

--- a/app/.rubocop.yml
+++ b/app/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
 
 Style/HashSyntax:

--- a/app/lib/bk/compat/parsers/bitbucket/clone.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/clone.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative '../../pipeline/step'
+require_relative '../../pipeline/plugin'
+
+module BK
+  module Compat
+    module BitBucketSteps
+      # Translatio of clone options
+      class Step
+        def translate_clone(opts)
+          sparse_checkout = opts.delete('sparse-checkout')
+          enabled = opts.delete('enabled')
+          msg = '# repository interactions (clone options) should be configured in the agent itself'
+
+          # nothing specified
+          return [] if sparse_checkout.nil? && enabled.nil? && opts.empty?
+
+          BK::Compat::CommandStep.new(commands: msg).tap do |cmd|
+            cmd.env['BUILKITE_REPO'] = '' unless enabled.nil? || enabled
+            cmd << sparse_checkout_plugin(sparse_checkout)
+          end
+        end
+
+        def sparse_checkout_plugin(conf)
+          return [] if conf.nil? || !conf.fetch('enabled', true)
+
+          BK::Compat::Plugin.new(
+            name: 'sparse-checkout',
+            config: {
+              'paths' => conf['patterns'],
+              'no-cone' => !conf.fetch('cone-mode', true)
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/lib/bk/compat/parsers/bitbucket/steps.rb
+++ b/app/lib/bk/compat/parsers/bitbucket/steps.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 require_relative '../../pipeline/step'
-require_relative '../../pipeline/plugin'
 
 require_relative 'caches'
+require_relative 'clone'
 require_relative 'image'
 require_relative 'services'
 require_relative 'shared'
@@ -95,32 +95,6 @@ module BK
             'BITBUCKET_STEP_OIDC_TOKEN="$(buildkite-agent oidc request-token)"',
             'export BITBUCKET_STEP_OIDC_TOKEN'
           ]
-        end
-
-        def translate_clone(opts)
-          sparse_checkout = opts.delete('sparse-checkout')
-          enabled = opts.delete('enabled')
-          msg = '# repository interactions (clone options) should be configured in the agent itself'
-
-          # nothing specified
-          return [] if sparse_checkout.nil? && enabled.nil? && opts.empty?
-
-          BK::Compat::CommandStep.new(commands: msg).tap do |cmd|
-            cmd.env['BUILKITE_REPO'] = '' unless enabled.nil? || enabled
-            cmd << sparse_checkout_plugin(sparse_checkout)
-          end
-        end
-
-        def sparse_checkout_plugin(conf)
-          return [] if conf.nil? || !conf.fetch('enabled', true)
-
-          BK::Compat::Plugin.new(
-            name: 'sparse-checkout',
-            config: {
-              'paths' => conf['patterns'],
-              'no-cone' => !conf.fetch('cone-mode', true)
-            }
-          )
         end
 
         def translate_agents(conf)

--- a/app/lib/bk/compat/parsers/circleci/docker.rb
+++ b/app/lib/bk/compat/parsers/circleci/docker.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require_relative '../../pipeline/plugin'
+require_relative '../../pipeline/step'
+
+module BK
+  module Compat
+    # CircleCI translation of workflows
+    class CircleCI
+      private
+
+      def executor_docker(config)
+        first, *rest = config # split first configuration
+
+        BK::Compat::CircleCISteps::CircleCIStep.new.tap do |step|
+          step.agents['executor_type'] = 'docker'
+          step << executor_docker_auth_plugin(first.fetch('auth', {}))
+          step << executor_docker_aws_auth(first.fetch('aws-auth', {}))
+
+          step << (rest.empty? ? executor_docker_plugin(first) : executor_docker_compose_plugin(first, *rest))
+        end
+      end
+
+      def executor_docker_auth_plugin(auth_config)
+        return [] if auth_config.empty?
+
+        BK::Compat::Plugin.new(
+          name: 'docker-login',
+          config: {
+            'username' => auth_config['username'],
+            'password-env' => auth_config['password'].ltrim('$')
+          }
+        )
+      end
+
+      def executor_docker_aws_auth(config)
+        return [] if config.empty?
+
+        url_regex = '^(?:[^/]+//)?(?<account-ids>\d+).dkr.ecr.(?<region>[^.]+).amazonaws.com'
+        cfg = config['image'].match(url_regex).named_captures
+
+        cfg[:login] = true
+        cfg['assume-role'] = { 'role-arn' => config['oidc_role_arn'] } if config.include?('oidc_role_arn')
+
+        BK::Compat::CircleCISteps::CircleCIStep.new(
+          plugins: [BK::Compat::Plugin.new(name: 'ecr', config: cfg)]
+        ).tap do |step|
+          if config.include?('aws_access_key_id')
+            step.add_commands('# Configure the agent to have the appropriate credentials for ECR auth')
+          end
+        end
+      end
+
+      def executor_docker_plugin(config)
+        plugin_config = config.slice('image', 'entrypoint', 'user', 'command', 'environment')
+        plugin_config['add-host'] = "${config['name']}:127.0.0.1" if config.include?('name')
+
+        BK::Compat::Plugin.new(
+          name: 'docker',
+          config: plugin_config
+        )
+      end
+
+      def executor_docker_compose_plugin(*apps)
+        containers = {}
+        apps.each_with_index do |app, i|
+          config = app.slice('image', 'entrypoint', 'user', 'command', 'environment')
+          name = config.fetch('name', "service#{i}")
+
+          containers[name] = config
+        end
+
+        conf = { 'services' => containers }
+        cmds = [
+          '# to make multiple images work, add the following composefile to your repository',
+          "cat > compose.yaml << EOF\n#{conf.to_yaml}\nEOF"
+        ]
+        plugin_config = { 'run' => apps[0].fetch('name', 'service0') }
+
+        BK::Compat::CircleCISteps::CircleCIStep.new(
+          key: 'docker compose',
+          commands: cmds,
+          agents: { 'executor_type' => 'docker_compose' },
+          plugins: [
+            BK::Compat::Plugin.new(
+              name: 'docker-compose',
+              config: plugin_config
+            )
+          ]
+        )
+      end
+    end
+  end
+end

--- a/app/lib/bk/compat/parsers/circleci/executors.rb
+++ b/app/lib/bk/compat/parsers/circleci/executors.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'steps'
+require_relative '../../pipeline/plugin'
+require_relative '../../pipeline/step'
+
+require_relative 'docker'
 
 module BK
   module Compat
@@ -41,91 +44,6 @@ module BK
           step.add_commands('# shell should be configured in the agent') unless shell.nil?
           step << send("executor_#{type}", conf)
         end
-      end
-
-      def executor_docker(config)
-        first, *rest = config # split first configuration
-
-        BK::Compat::CircleCISteps::CircleCIStep.new.tap do |step|
-          step.agents['executor_type'] = 'docker'
-          step << executor_docker_auth_plugin(first.fetch('auth', {}))
-          step << executor_docker_aws_auth(first.fetch('aws-auth', {}))
-
-          step << (rest.empty? ? executor_docker_plugin(first) : executor_docker_compose_plugin(first, *rest))
-        end
-      end
-
-      def executor_docker_auth_plugin(auth_config)
-        return [] if auth_config.empty?
-
-        BK::Compat::Plugin.new(
-          name: 'docker-login',
-          config: {
-            'username' => auth_config['username'],
-            'password-env' => auth_config['password'].ltrim('$')
-          }
-        )
-      end
-
-      def executor_docker_aws_auth(config)
-        return [] if config.empty?
-
-        BK::Compat::CircleCISteps::CircleCIStep.new.tap do |step|
-          if config.include?('aws_access_key_id')
-            step.add_commands('# Configure the agent to have the appropriate credentials for ECR auth')
-          end
-
-          url_regex = '^(?:[^/]+//)?(\d+).dkr.ecr.([^.]+).amazonaws.com'
-          account_id, region = config['image'].match(url_regex).captures
-          cfg = {
-            'login' => true,
-            'account-ids' => account_id,
-            'region' => region
-          }
-
-          cfg['assume-role'] = { 'role-arn' => config['oidc_role_arn'] } if config.include?('oidc_role_arn')
-
-          step << BK::Compat::Plugin.new(name: 'ecr', config: cfg)
-        end
-      end
-
-      def executor_docker_plugin(config)
-        plugin_config = config.slice('image', 'entrypoint', 'user', 'command', 'environment')
-        plugin_config['add-host'] = "${config['name']}:127.0.0.1" if config.include?('name')
-
-        BK::Compat::Plugin.new(
-          name: 'docker',
-          config: plugin_config
-        )
-      end
-
-      def executor_docker_compose_plugin(*apps)
-        containers = {}
-        apps.each_with_index do |app, i|
-          config = app.slice('image', 'entrypoint', 'user', 'command', 'environment')
-          name = config.fetch('name', "service#{i}")
-
-          containers[name] = config
-        end
-
-        conf = { 'services' => containers }
-        cmds = [
-          '# to make multiple images work, add the following composefile to your repository',
-          "cat > compose.yaml << EOF\n#{conf.to_yaml}\nEOF"
-        ]
-        plugin_config = { 'run' => apps[0].fetch('name', 'service0') }
-
-        BK::Compat::CircleCISteps::CircleCIStep.new(
-          key: 'docker compose',
-          commands: cmds,
-          agents: { 'executor_type' => 'docker_compose' },
-          plugins: [
-            BK::Compat::Plugin.new(
-              name: 'docker-compose',
-              config: plugin_config
-            )
-          ]
-        )
       end
 
       def executor_machine(config)

--- a/app/lib/bk/compat/parsers/gha/jobs.rb
+++ b/app/lib/bk/compat/parsers/gha/jobs.rb
@@ -12,10 +12,7 @@ module BK
       def parse_job(name, config)
         bk_step = generate_base_step(name, config)
         bk_step << translate_concurrency(config['concurrency'])
-        bk_step.matrix = generate_matrix(config['strategy']&.fetch('matrix'))
         config['steps'].each { |step| bk_step << @translator.translate_step(step) }
-        bk_step.agents.update(config.slice('runs-on'))
-        bk_step.conditional = generate_if(config['if'])
 
         # these two should be last because they need to execute commands at the end
         bk_step << translate_outputs(config['outputs'], name)
@@ -31,7 +28,10 @@ module BK
           depends_on: Array(config['needs']),
           env: config.fetch('env', {}),
           timeout_in_minutes: config['timeout-minutes'],
-          soft_fail: config['continue-on-error']
+          soft_fail: config['continue-on-error'],
+          conditional: generate_if(config['if']),
+          agents: config.slice('runs-on'),
+          matrix: generate_matrix(config['strategy']&.fetch('matrix'))
         )
       end
 

--- a/app/lib/bk/compat/parsers/gha/steps/actions.rb
+++ b/app/lib/bk/compat/parsers/gha/steps/actions.rb
@@ -97,23 +97,20 @@ module BK
       end
 
       def obtain_java_distribution_image(distribution, java_version)
-        case distribution
-        # seemru, adopt-openj9 (moved to semeru)
-        when /semeru|adopt-openj9/
-          "ibm-semeru-runtimes:open-#{java_version}-jdk"
-        # temurin, adpot (moved to temurin), oracle (deprecated)
-        when /temurin|adopt|oracle/
-          "eclipse-temurin:#{java_version}-jdk-alpine"
-        when /zulu/
-          "azul/zulu-openjdk-alpine:t#{java_version}-latest"
-        when /liberica/
-          "bellsoft/liberica-openjdk-alpine:#{java_version}"
-        when /microsoft/
-          "mcr.microsoft.com/openjdk/jdk:#{java_version}-ubuntu"
-        when /coretto/
-          "amazoncorretto:#{java_version}-al2023-jdk"
-        when /dragonwell/
-          "alibabadragonwell/dragonwell:#{java_version}-alpine"
+        mapping = {
+          # seemru, adopt-openj9 (moved to semeru)
+          /semeru|adopt-openj9/ => "ibm-semeru-runtimes:open-#{java_version}-jdk",
+          # temurin, adpot (moved to temurin), oracle (deprecated)
+          /temurin|adopt|oracle/ => "eclipse-temurin:#{java_version}-jdk-alpine",
+          /zulu/ => "azul/zulu-openjdk-alpine:t#{java_version}-latest",
+          /liberica/ => "bellsoft/liberica-openjdk-alpine:#{java_version}",
+          /microsoft/ => "mcr.microsoft.com/openjdk/jdk:#{java_version}-ubuntu",
+          /coretto/ => "amazoncorretto:#{java_version}-al2023-jdk",
+          /dragonwell/ => "alibabadragonwell/dragonwell:#{java_version}-alpine"
+        }
+
+        mapping.each do |regex, result|
+          return result if distribution.match(regex)
         end
       end
     end


### PR DESCRIPTION
I have long been running `rubocop` without `-l` as a stricter linter variant that mostly complains about:

* code complexity
* block length
* trailing whitespace

This PR includes refactorings to remove the last 8 warnings (and ignores one).

To further prevent this from being an issue I created an [EditorConfig](https://editorconfig.org/) file to prevent the easier automated warnings (as long as your IDE supports it, which it should - maybe with an extension)