### PR TITLE
CircleCI when steps

### DIFF
--- a/app/lib/bk/compat/parsers/circleci.rb
+++ b/app/lib/bk/compat/parsers/circleci.rb
@@ -62,7 +62,7 @@ module BK
       private
 
       def register_translators!
-        @translator = BK::Compat::StepTranslator.new
+        @translator = BK::Compat::StepTranslator.new(recursor: method(:translate_steps).to_proc)
         @translator.register(
           BK::Compat::CircleCISteps::Builtins.new
         )
@@ -85,6 +85,15 @@ module BK
         groups = groups.first.steps.each { |step| step.conditional = groups.first.conditional } if groups.length == 1
 
         groups
+      end
+
+      def translate_steps(step_list)
+        return [] if step_list.nil?
+
+        step_list.map do |circle_step|
+          key, config = string_or_key(circle_step)
+          @commands_by_key[key]&.instantiate(config) || @translator.translate_step(key, config)
+        end
       end
 
       def string_or_key(job)

--- a/app/lib/bk/compat/parsers/circleci/jobs.rb
+++ b/app/lib/bk/compat/parsers/circleci/jobs.rb
@@ -43,15 +43,6 @@ module BK
           bk_step.parameters = config.fetch('parameters', {})
         end
       end
-
-      def translate_steps(step_list)
-        return [] if step_list.nil?
-
-        step_list.map do |circle_step|
-          key, config = string_or_key(circle_step)
-          @commands_by_key[key]&.instantiate(config) || @translator.translate_step(key, config)
-        end
-      end
     end
   end
 end

--- a/app/lib/bk/compat/parsers/circleci/steps.rb
+++ b/app/lib/bk/compat/parsers/circleci/steps.rb
@@ -109,7 +109,7 @@ module BK
 
         def translate_when(config)
           condition = BK::Compat::CircleCI.parse_condition(config['condition'])
-          commands = config['steps'].map { |s| recursor(*s.to_a.flatten) }
+          commands = recursor(config['steps'])
           [
             '# when condition translation may not be compatible with your shell',
             "if [ #{condition} ]; then"

--- a/app/lib/bk/compat/parsers/circleci/steps.rb
+++ b/app/lib/bk/compat/parsers/circleci/steps.rb
@@ -109,11 +109,14 @@ module BK
 
         def translate_when(config)
           condition = BK::Compat::CircleCI.parse_condition(config['condition'])
-          commands = recursor(config['steps'])
-          [
-            '# when condition translation may not be compatible with your shell',
-            "if [ #{condition} ]; then"
-          ] + commands.compact + ['fi']
+          CircleCIStep.new.tap do |c|
+            c << [
+              '# when condition translation may not be compatible with your shell',
+              "if [ #{condition} ]; then"
+            ]
+            recursor(config['steps']).each { |s| c << s }
+            c << 'fi'
+          end
         end
       end
 

--- a/app/lib/bk/compat/translator.rb
+++ b/app/lib/bk/compat/translator.rb
@@ -4,15 +4,16 @@ module BK
   module Compat
     # Dispatch pattern for step translation
     class StepTranslator
-      def initialize(default: nil)
+      def initialize(default: nil, recursor: nil)
         @default_func = default.nil? ? method(:default_value) : default
+        @recursor = recursor || method(:translate_step).to_proc
         @translators = []
       end
 
       def register(*translators)
         translators.each do |tr|
           # allow translator to have a `recursor` function available
-          tr.define_singleton_method(:recursor, method(:translate_step).to_proc)
+          tr.define_singleton_method(:recursor, @recursor)
           @translators << tr
         end
       end

--- a/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/conditions.yml.snap
+++ b/app/spec/lib/bk/compat/circleci/__snapshots__/spec/lib/bk/compat/circleci/examples/conditions.yml.snap
@@ -10,6 +10,7 @@ steps:
     - "# when condition translation may not be compatible with your shell"
     - if [ "<< pipeline.git.branch >>" == "main" ]; then
     - echo 'Running in main'
+    - echo 'Running command'
     - fi
     key: test
 - group: ":circleci: my-workflow-2"

--- a/app/spec/lib/bk/compat/circleci/examples/conditions.yml
+++ b/app/spec/lib/bk/compat/circleci/examples/conditions.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+commands:
+  custom_command:
+    steps:
+      - run: echo 'Running command'
+
 jobs:
   test:
     steps:
@@ -9,6 +14,7 @@ jobs:
             equal: [ main, << pipeline.git.branch >> ]
           steps:
             - run: echo 'Running in main'
+            - custom_command
   build-and-package:
     environment:
       DEPLOY_ENV: staging


### PR DESCRIPTION
CircleCI when steps in jobs can also call pre-defined commands, and that was not being processed correctly with the following error:

```
Failure/Error: commands = config['steps'].map { |s| recursor(*s.to_a.flatten) }
     
     NoMethodError:
       undefined method `to_a' for an instance of String
```

To solve this I needed the translation's `recursor` to be something else and not just a single step translation that did not have access to the context of the pipeline being parsed so I just made that customizable. After that, the code to handle the situation already existed in the job parsing function so I moved it to the general class file and used it to instantiate the translator.

Obviously, I updated the test for `when` conditionals with a minor change to also include this scenario.