### PR TITLE
SUP-1802: Dependabot bundler/docker configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: '/app'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
Added Dependabot config for both Bundler/gem and Docker image configuration.

I've put it in as daily for now, if the version bumps get too verbose, they can be dialled down to a wider interval