### PR TITLE
SUP-2399: Bitrise `script` step translation & configuration loader reworked 

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'activesupport'
 gem 'parslet'
 gem 'rack'
 gem 'rackup' # necessary for starting the HTTP interface

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -1,11 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
     ast (2.4.2)
     awesome_print (1.9.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    minitest (5.24.1)
+    mutex_m (0.2.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -52,6 +71,8 @@ GEM
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     strscan (3.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
 
@@ -61,6 +82,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport
   parslet
   rack
   rackup

--- a/app/lib/bk/compat/parsers/bitrise.rb
+++ b/app/lib/bk/compat/parsers/bitrise.rb
@@ -42,10 +42,10 @@ module BK
         load_workflows!
 
         workflows = @config.fetch('workflows', {})
-        bk_groups = workflows.map { |wf_name, wf_config| parse_workflow(wf_name, wf_config) }
+        bk_steps = workflows.map { |wf_name, wf_config| parse_workflow(wf_name, wf_config) }
 
         Pipeline.new(
-          steps: bk_groups
+          steps: bk_steps
         )
       end
 

--- a/app/lib/bk/compat/parsers/bitrise.rb
+++ b/app/lib/bk/compat/parsers/bitrise.rb
@@ -5,6 +5,7 @@ require_relative '../pipeline'
 require_relative '../pipeline/step'
 require_relative 'bitrise/steps'
 require_relative 'bitrise/workflows'
+require_relative 'bitrise/loader'
 
 module BK
   module Compat
@@ -32,11 +33,14 @@ module BK
       def initialize(text, options = {})
         @config = YAML.safe_load(text, aliases: true)
         @options = options
+        @steps_by_key = {}
 
         register_translators!
       end
 
       def parse
+        load_workflows!
+
         workflows = @config.fetch('workflows', {})
         bk_groups = workflows.map { |wf_name, wf_config| parse_workflow(wf_name, wf_config) }
 
@@ -50,6 +54,10 @@ module BK
       def register_translators!
         @translator = BK::Compat::StepTranslator.new
         @translator.register(BK::Compat::BitriseSteps::Translator.new)
+      end
+
+      def load_workflows!
+        @config.fetch('workflows', {}).map { |key, config| load_workflow(key, config) }
       end
     end
   end

--- a/app/lib/bk/compat/parsers/bitrise/loader.rb
+++ b/app/lib/bk/compat/parsers/bitrise/loader.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BK
+  module Compat
+    # Bitrise configuration loader
+    class Bitrise
+      def load_workflow(key, config)
+        load_workflow_steps(key, config)
+      end
+
+      def load_workflow_steps(key, config)
+        cmds = []
+        config['steps'].each do |step| 
+          step_key, step_config = step.first
+          step_key_normalized = normalize_step_type(step_key)
+          cmd = @translator.translate_step(step_key_normalized, step_config)
+        end
+      end
+
+      def normalize_step_key(step)
+        # Pull out the step type without its version to match translator's supported steps
+        step.match?(STEP_TYPE_REGEX) ? step.match(STEP_TYPE_REGEX)[1] : step
+      end
+    end
+  end
+end

--- a/app/lib/bk/compat/parsers/bitrise/loader.rb
+++ b/app/lib/bk/compat/parsers/bitrise/loader.rb
@@ -4,7 +4,7 @@ module BK
   module Compat
     # Bitrise workflow configuration loader
     class Bitrise
-      STEP_KEY_REGEX = /([a-zA-Z]*)@(\d*|0)(\.((\d*)|0)){0,3}/
+      STEP_KEY_REGEX = /([a-zA-Z-]*)@(\d*|0)(\.((\d*)|0)){0,3}/
 
       def load_workflow(key, config)
         raise "Duplicate workflow name: #{key}" if @steps_by_key.include?(key)
@@ -13,19 +13,21 @@ module BK
       end
 
       def load_workflow_steps(key, config)
+        # Extend for other types of steps - approvals/waits for example.
         BK::Compat::CommandStep.new(label: key, key: key).tap do |cmd_step|
           config['steps'].each do |step|
             step_key, step_config = step.first
-            cmd_step.commands << load_workflow_step(step_key, step_config)
+            step_inputs = step_config['inputs'].reduce({}, :merge)
+            cmd_step.commands << load_workflow_step(step_key, step_inputs)
           end
         end
       end
 
-      def load_workflow_step(step_key, step_config)
+      def load_workflow_step(step_key, step_inputs)
         step_key_normalized = normalize_step_key(step_key)
 
-        # Translate step with normalized key (for translator) and its configuration
-        @translator.translate_step(step_key_normalized, step_config)
+        # Translate step with normalized key (for translator) and its input configuration
+        @translator.translate_step(step_key_normalized, step_inputs)
       end
 
       def normalize_step_key(step_key)

--- a/app/lib/bk/compat/parsers/bitrise/loader.rb
+++ b/app/lib/bk/compat/parsers/bitrise/loader.rb
@@ -2,24 +2,35 @@
 
 module BK
   module Compat
-    # Bitrise configuration loader
+    # Bitrise workflow configuration loader
     class Bitrise
+      STEP_KEY_REGEX = /([a-zA-Z]*)@(\d*|0)(\.((\d*)|0)){0,3}/
+
       def load_workflow(key, config)
-        load_workflow_steps(key, config)
+        raise "Duplicate workflow name: #{key}" if @steps_by_key.include?(key)
+
+        @steps_by_key[key] = load_workflow_steps(key, config)
       end
 
       def load_workflow_steps(key, config)
-        cmds = []
-        config['steps'].each do |step| 
-          step_key, step_config = step.first
-          step_key_normalized = normalize_step_type(step_key)
-          cmd = @translator.translate_step(step_key_normalized, step_config)
+        BK::Compat::CommandStep.new(label: key, key: key).tap do |cmd_step|
+          config['steps'].each do |step|
+            step_key, step_config = step.first
+            cmd_step.commands << load_workflow_step(step_key, step_config)
+          end
         end
       end
 
-      def normalize_step_key(step)
-        # Pull out the step type without its version to match translator's supported steps
-        step.match?(STEP_TYPE_REGEX) ? step.match(STEP_TYPE_REGEX)[1] : step
+      def load_workflow_step(step_key, step_config)
+        step_key_normalized = normalize_step_key(step_key)
+
+        # Translate step with normalized key (for translator) and its configuration
+        @translator.translate_step(step_key_normalized, step_config)
+      end
+
+      def normalize_step_key(step_key)
+        # Pull out the step key without its version to match translator's supported steps
+        step_key.match?(STEP_KEY_REGEX) ? step_key.match(STEP_KEY_REGEX)[1] : step_key
       end
     end
   end

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -16,9 +16,9 @@ module BK
         end
 
         def translate_script(config)
-          BK::Compat::CommandStep.new(
-            commands: [config['inputs'].first['content']]
-          )
+          [
+            config['inputs'].first['content']
+          ]
         end
       end
     end

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -1,23 +1,47 @@
 # frozen_string_literal: true
 
+require 'active_support//core_ext/object/blank'
+
 module BK
   module Compat
     module BitriseSteps
       # Implementation of Bitrise step translations
       class Translator
-        VALID_STEP_TYPES = %w[script].freeze
+        VALID_STEP_TYPES = %w[change-workdir git-clone script].freeze
 
-        def matcher(type, _config)
+        def matcher(type, _inputs)
           VALID_STEP_TYPES.include?(type.downcase)
         end
 
-        def translator(type, config)
-          send("translate_#{type.downcase.gsub('-', '_')}", config)
+        def translator(type, inputs)
+          send("translate_#{type.downcase.gsub('-', '_')}", inputs)
         end
 
-        def translate_script(config)
+        def translate_change_workdir(inputs)
           [
-            config['inputs'].first['content']
+            generate_change_workdir_command(inputs['path'], inputs['is_create_path'])
+          ]
+        end
+
+        def generate_change_workdir_command(path, is_create_path)
+          if is_create_path && path.present?
+            "mkdir #{path} && cd #{path}"
+          elsif !is_create_path && path.present?
+            "cd #{path}"
+          else
+            '# Invalid change-workdir step configuration!'
+          end
+        end
+
+        def translate_git_clone(_inputs)
+          [
+            ['# No need for cloning, the agent takes care of that']
+          ]
+        end
+
+        def translate_script(inputs)
+          [
+            inputs['content']
           ]
         end
       end

--- a/app/lib/bk/compat/parsers/bitrise/workflows.rb
+++ b/app/lib/bk/compat/parsers/bitrise/workflows.rb
@@ -4,35 +4,12 @@ module BK
   module Compat
     # Bitrise translation of workflows
     class Bitrise
-      STEP_TYPE_REGEX = /([a-zA-Z]*)@(\d*|0)(\.((\d*)|0)){0,3}/
-
       private
 
-      def parse_workflow(wf_name, wf_config)
-        bk_steps = parse_workflow_steps(wf_config)
+      def parse_workflow(wf_name, _wf_config)
+        raise "No key within loaded workflow configuration for #{wf_name}" unless @steps_by_key.include?(wf_name)
 
-        BK::Compat::GroupStep.new(
-          label: wf_name,
-          key: wf_name,
-          steps: bk_steps
-        )
-      end
-
-      def parse_workflow_steps(wf_config)
-        wf_config['steps'].map { |step| process_step(step) }
-      end
-
-      def process_step(step)
-        # Obtain steps' key, config, and normalize it
-        step_key, step_config = step.first
-        step_key_normalized = normalize_step_type(step_key)
-
-        @translator.translate_step(step_key_normalized, step_config)
-      end
-
-      def normalize_step_type(step)
-        # Pull out the step type without its version to match translator's supported steps
-        step.match?(STEP_TYPE_REGEX) ? step.match(STEP_TYPE_REGEX)[1] : step
+        @steps_by_key[wf_name]
       end
     end
   end

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml.snap
@@ -1,0 +1,19 @@
+---
+steps:
+- commands:
+  - "# No need for cloning, the agent takes care of that"
+  - mkdir bitrise-ex/build && cd bitrise-ex/build
+  - "./build-app.sh"
+  label: build
+  key: build
+- commands:
+  - "# No need for cloning, the agent takes care of that"
+  - "# Invalid change-workdir step configuration!"
+  - "./test.sh"
+  label: test
+  key: test
+- commands:
+  - cd bitrise-ex/deploy/
+  - "./deploy-app.sh"
+  label: deploy
+  key: deploy

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/example.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/example.yml.snap
@@ -1,7 +1,6 @@
 ---
 steps:
-- group: test
+- commands:
+  - echo "Hello ${MY_NAME}!"
+  label: test
   key: test
-  steps:
-  - commands:
-    - echo "Hello ${MY_NAME}!"

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-clone.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-clone.yml.snap
@@ -1,0 +1,11 @@
+---
+steps:
+- commands:
+  - "# No need for cloning, the agent takes care of that"
+  - "./build-app.sh"
+  label: build
+  key: build
+- commands:
+  - "./deploy-app.sh"
+  label: deploy
+  key: deploy

--- a/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
+++ b/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
@@ -1,0 +1,37 @@
+format_version: 11
+default_step_lib_source: https://github.com/example/example-bitrise.git
+project_type: ios
+
+workflows:
+  build:
+    steps:
+    - git-clone@2.2.1:
+        inputs:
+        - repository_url: git@github.com:example/example-repository.git
+    - change-workdir@1.0.3:
+        inputs:
+        - path: bitrise-ex/build
+        - is_create_path: true
+    - script@1.1.5:
+        inputs:
+        - content: ./build-app.sh
+  test:
+    steps:
+    - git-clone@2.2.1:
+        inputs:
+        - repository_url: git@github.com:example/example-repository.git
+    - change-workdir@1.0.3:
+        inputs:
+        - is_create_path: true
+    - script@1.1.5:
+        inputs:
+        - content: ./test.sh
+  deploy:
+    steps:  
+    - change-workdir@1.0.3:
+        inputs:
+        - path: bitrise-ex/deploy/
+        - is_create_path: false
+    - script@1.1.5:
+        inputs:
+        - content: ./deploy-app.sh

--- a/app/spec/lib/bk/compat/bitrise/examples/git-clone.yml
+++ b/app/spec/lib/bk/compat/bitrise/examples/git-clone.yml
@@ -1,0 +1,19 @@
+format_version: 11
+default_step_lib_source: https://github.com/example/example-bitrise.git
+project_type: ios
+
+workflows:
+  build:
+    steps:
+    - git-clone@8.2.2:
+        inputs:
+        - clone_into_dir: /tmp/bitrise-ex/
+        - repository_url: git@github.com:example/example-repository.git
+    - script@1.1.5:
+        inputs:
+        - content: ./build-app.sh
+  deploy:
+    steps:  
+    - script@1.1.5:
+        inputs:
+        - content: ./deploy-app.sh


### PR DESCRIPTION
This PR builds upon #141 and introducing new workflow loading configuration in addition to supporting `script` steps in a more extensible manner.

All Bitrise `workflows` are now loaded in upon parsing start, and translation occurs in grabbing the relevant value from the `steps_by_key` Hash. In the `load_workflows!` def - translation occurs for matching _normalized_ step keys (without SemVer suffix such as `script@1.1.5`) which will be the basis for additional step type translation.

Merge this before #141