### PR TITLE
SUP-2426: Bitrise `change-workdir` step translation

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+gem 'activesupport'
 gem 'parslet'
 gem 'rack'
 gem 'rackup' # necessary for starting the HTTP interface

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -1,11 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
     ast (2.4.2)
     awesome_print (1.9.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
     diff-lcs (1.5.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    minitest (5.24.1)
+    mutex_m (0.2.0)
     parallel (1.25.1)
     parser (3.3.3.0)
       ast (~> 2.4.1)
@@ -52,6 +71,8 @@ GEM
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
     strscan (3.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
 
@@ -61,6 +82,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activesupport
   parslet
   rack
   rackup

--- a/app/lib/bk/compat/parsers/bitrise/loader.rb
+++ b/app/lib/bk/compat/parsers/bitrise/loader.rb
@@ -13,19 +13,21 @@ module BK
       end
 
       def load_workflow_steps(key, config)
+        # Extend for other types of steps - approvals/waits for example.
         BK::Compat::CommandStep.new(label: key, key: key).tap do |cmd_step|
           config['steps'].each do |step|
             step_key, step_config = step.first
-            cmd_step.commands << load_workflow_step(step_key, step_config)
+            step_inputs = step_config['inputs'].reduce({}, :merge)
+            cmd_step.commands << load_workflow_step(step_key, step_inputs)
           end
         end
       end
 
-      def load_workflow_step(step_key, step_config)
+      def load_workflow_step(step_key, step_inputs)
         step_key_normalized = normalize_step_key(step_key)
 
-        # Translate step with normalized key (for translator) and its configuration
-        @translator.translate_step(step_key_normalized, step_config)
+        # Translate step with normalized key (for translator) and its input configuration
+        @translator.translate_step(step_key_normalized, step_inputs)
       end
 
       def normalize_step_key(step_key)

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -9,17 +9,17 @@ module BK
       class Translator
         VALID_STEP_TYPES = %w[change-workdir git-clone script].freeze
 
-        def matcher(type, _config)
+        def matcher(type, _inputs)
           VALID_STEP_TYPES.include?(type.downcase)
         end
 
-        def translator(type, config)
-          send("translate_#{type.downcase.gsub('-', '_')}", config)
+        def translator(type, inputs)
+          send("translate_#{type.downcase.gsub('-', '_')}", inputs)
         end
 
-        def translate_change_workdir(config)
+        def translate_change_workdir(inputs)
           [
-            generate_change_workdir_command(config['path'], config['is_create_path'])
+            generate_change_workdir_command(inputs['path'], inputs['is_create_path'])
           ]
         end
 
@@ -33,15 +33,15 @@ module BK
           end
         end
 
-        def translate_git_clone(_config)
+        def translate_git_clone(_inputs)
           [
             ['# No need for cloning, the agent takes care of that']
           ]
         end
 
-        def translate_script(config)
+        def translate_script(inputs)
           [
-            config['inputs'].first['content']
+            inputs['content']
           ]
         end
       end

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -25,11 +25,11 @@ module BK
 
         def generate_change_workdir_command(path, is_create_path)
           if is_create_path && path.present?
-            "mkdir #{path} && cd #{path}" 
+            "mkdir #{path} && cd #{path}"
           elsif !is_create_path && path.present?
             "cd #{path}"
           else
-            "# Invalid change-workdir step configuration!"
+            '# Invalid change-workdir step configuration!'
           end
         end
 

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
+require 'active_support//core_ext/object/blank'
+
 module BK
   module Compat
     module BitriseSteps
       # Implementation of Bitrise step translations
       class Translator
-        VALID_STEP_TYPES = %w[git-clone script].freeze
+        VALID_STEP_TYPES = %w[change-workdir git-clone script].freeze
 
         def matcher(type, _config)
           VALID_STEP_TYPES.include?(type.downcase)
@@ -13,6 +15,22 @@ module BK
 
         def translator(type, config)
           send("translate_#{type.downcase.gsub('-', '_')}", config)
+        end
+
+        def translate_change_workdir(config)
+          generate_change_workdir_command(config['path'], config['is_create_path'])
+        end
+
+        def generate_change_workdir_command(path, create_directory)
+          if create_directory && path.present?
+            [
+              "mkdir #{path} && cd #{path}"
+            ]
+          elsif !create_directory && path.present?
+            [
+              "cd #{path}"
+            ]
+          end
         end
 
         def translate_git_clone(_config)

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -23,10 +23,10 @@ module BK
           ]
         end
 
-        def generate_change_workdir_command(path, create_directory)
-          if create_directory && path.present?
+        def generate_change_workdir_command(path, is_create_path)
+          if is_create_path && path.present?
             "mkdir #{path} && cd #{path}" 
-          elsif !create_directory && path.present?
+          elsif !is_create_path && path.present?
             "cd #{path}"
           else
             "# Invalid change-workdir step configuration!"

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -18,18 +18,18 @@ module BK
         end
 
         def translate_change_workdir(config)
-          generate_change_workdir_command(config['path'], config['is_create_path'])
+          [
+            generate_change_workdir_command(config['path'], config['is_create_path'])
+          ]
         end
 
         def generate_change_workdir_command(path, create_directory)
           if create_directory && path.present?
-            [
-              "mkdir #{path} && cd #{path}"
-            ]
+            "mkdir #{path} && cd #{path}" 
           elsif !create_directory && path.present?
-            [
-              "cd #{path}"
-            ]
+            "cd #{path}"
+          else
+            "# Invalid change-workdir step configuration!"
           end
         end
 

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml.snap
@@ -1,0 +1,13 @@
+---
+steps:
+- commands:
+  - "# No need for cloning, the agent takes care of that"
+  - mkdir bitrise-ex/build && cd bitrise-ex/build
+  - "./build-app.sh"
+  label: build
+  key: build
+- commands:
+  - cd bitrise-ex/deploy/
+  - "./deploy-app.sh"
+  label: deploy
+  key: deploy

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml.snap
@@ -7,6 +7,12 @@ steps:
   label: build
   key: build
 - commands:
+  - "# No need for cloning, the agent takes care of that"
+  - "# Invalid change-workdir step configuration!"
+  - "./test.sh"
+  label: test
+  key: test
+- commands:
   - cd bitrise-ex/deploy/
   - "./deploy-app.sh"
   label: deploy

--- a/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
+++ b/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
@@ -6,27 +6,32 @@ workflows:
   build:
     steps:
     - git-clone@2.2.1:
-        repository_url: git@github.com:example/example-repository.git
+        inputs:
+        - repository_url: git@github.com:example/example-repository.git
     - change-workdir@1.0.3:
-        path: bitrise-ex/build
-        is_create_path: true
+        inputs:
+        - path: bitrise-ex/build
+        - is_create_path: true
     - script@1.1.5:
         inputs:
         - content: ./build-app.sh
   test:
     steps:
     - git-clone@2.2.1:
-        repository_url: git@github.com:example/example-repository.git
+        inputs:
+        - repository_url: git@github.com:example/example-repository.git
     - change-workdir@1.0.3:
-        is_create_path: true
+        inputs:
+        - is_create_path: true
     - script@1.1.5:
         inputs:
         - content: ./test.sh
   deploy:
     steps:  
     - change-workdir@1.0.3:
-        path: bitrise-ex/deploy/
-        is_create_path: false
+        inputs:
+        - path: bitrise-ex/deploy/
+        - is_create_path: false
     - script@1.1.5:
         inputs:
         - content: ./deploy-app.sh

--- a/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
+++ b/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
@@ -13,6 +13,15 @@ workflows:
     - script@1.1.5:
         inputs:
         - content: ./build-app.sh
+  test:
+    steps:
+    - git-clone@2.2.1:
+        repository_url: git@github.com:example/example-repository.git
+    - change-workdir@1.0.3:
+        is_create_path: true
+    - script@1.1.5:
+        inputs:
+        - content: ./test.sh
   deploy:
     steps:  
     - change-workdir@1.0.3:

--- a/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
+++ b/app/spec/lib/bk/compat/bitrise/examples/change-workdir.yaml
@@ -1,0 +1,23 @@
+format_version: 11
+default_step_lib_source: https://github.com/example/example-bitrise.git
+project_type: ios
+
+workflows:
+  build:
+    steps:
+    - git-clone@2.2.1:
+        repository_url: git@github.com:example/example-repository.git
+    - change-workdir@1.0.3:
+        path: bitrise-ex/build
+        is_create_path: true
+    - script@1.1.5:
+        inputs:
+        - content: ./build-app.sh
+  deploy:
+    steps:  
+    - change-workdir@1.0.3:
+        path: bitrise-ex/deploy/
+        is_create_path: false
+    - script@1.1.5:
+        inputs:
+        - content: ./deploy-app.sh

--- a/app/spec/lib/bk/compat/bitrise/examples/git-clone.yml
+++ b/app/spec/lib/bk/compat/bitrise/examples/git-clone.yml
@@ -6,8 +6,9 @@ workflows:
   build:
     steps:
     - git-clone@8.2.2:
-        clone_into_dir: /tmp/bitrise-ex/
-        repository_url: git@github.com:example/example-repository.git
+        inputs:
+        - clone_into_dir: /tmp/bitrise-ex/
+        - repository_url: git@github.com:example/example-repository.git
     - script@1.1.5:
         inputs:
         - content: ./build-app.sh


### PR DESCRIPTION
This PR builds upon #145  - introducing translation of `change-workdir` steps when defined in Bitrise YAML configuration.

Specific to `change-workdir` [steps](https://github.com/bitrise-io/bitrise-steplib/blob/master/steps/change-workdir/1.0.3/step.yml#L24-L45), two parameters can be defined: `path` which is the directory to `cd` into, and `is_create_path` - a boolean that specifies if the directory should be created before changing into. Combinations supported by this PR include `is_create_path` being true/false, but `path` must be set for this step type to function as expected.

To make implementation easier, I've introduced the `activesupport` gem for its `present?` method on objects to check for blankness for `path`.

This PR also adjusts the translation of step configuration - namely `inputs` are passed through to the translator and then each supported steps' configuration is built upon that. 
 
Merge this before #145 