### PR TITLE
SUP-2405: Bitrise `bundler` step translation

### DIFF
--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -34,7 +34,7 @@ module BK
             'brew install'
           end
         end
-        
+
         def translate_bundler(inputs)
           [
             generate_bundler_command(inputs)

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -7,7 +7,7 @@ module BK
     module BitriseSteps
       # Implementation of Bitrise step translations
       class Translator
-        VALID_STEP_TYPES = %w[brew-install change-workdir git-clone script].freeze
+        VALID_STEP_TYPES = %w[bundler brew-install change-workdir git-clone script].freeze
 
         def matcher(type, _inputs)
           VALID_STEP_TYPES.include?(type.downcase)
@@ -32,6 +32,23 @@ module BK
             'brew bundle'
           else
             'brew install'
+          end
+        end
+        
+        def translate_bundler(inputs)
+          [
+            generate_bundler_command(inputs)
+          ]
+        end
+
+        def generate_bundler_command(inputs)
+          install_jobs = inputs['bundle_install_jobs']
+          install_retry = inputs['bundle_install_retry']
+
+          if install_jobs.present? && install_retry.present?
+            "bundle check || bundle install --jobs #{install_jobs} --retry #{install_retry}"
+          else
+            '# Invalid bundler step configuration!'
           end
         end
 

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/bundler.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/bundler.yml.snap
@@ -1,0 +1,8 @@
+---
+steps:
+- commands:
+  - "# No need for cloning, the agent takes care of that"
+  - bundle check || bundle install --jobs 4 --retry 1
+  - "./build-app.sh"
+  label: build
+  key: build

--- a/app/spec/lib/bk/compat/bitrise/examples/bundler.yml
+++ b/app/spec/lib/bk/compat/bitrise/examples/bundler.yml
@@ -1,0 +1,18 @@
+format_version: 11
+default_step_lib_source: https://github.com/example/example-bitrise.git
+project_type: ios
+
+workflows:
+  build:
+    steps:
+    - git-clone@8.2.2:
+        inputs:
+        - clone_into_dir: /tmp/bitrise-ex/
+        - repository_url: git@github.com:example/example-repository.git
+    - bundler@0.0.4:
+        inputs:
+        - bundle_install_jobs: 4
+        - bundle_install_retry: 1
+    - script@1.1.5:
+        inputs:
+        - content: ./build-app.sh


### PR DESCRIPTION
This PR introduces translation of `bundler` steps when defined in Bitrise YAML configuration.

The step can take in two inputs that are mandatory - `bundle_install_jobs` (for `--jobs` flag/value) and `bundle_install_retry` (for `--retry` flag/value) for a `bundle install` command. The step itself does a `bundle check` beforehand too - which is replicated in the generated `CommandStep`'s commands when added.