### PR TITLE
SUP-2407: Bitrise `git-tag` step translation

### DIFF
--- a/app/lib/bk/compat/parsers/bitrise/commands.rb
+++ b/app/lib/bk/compat/parsers/bitrise/commands.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'active_support//core_ext/object/blank'
+
+module BK
+  module Compat
+    module BitriseSteps
+      # Implementation of Bitrise step translations
+      class Translator
+        def generate_brew_install_command(inputs)
+          if inputs['packages'].present? && inputs['upgrade']
+            "brew reinstall #{inputs['packages']}"
+          elsif inputs['packages'].present? && !inputs['upgrade']
+            "brew install #{inputs['packages']}"
+          elsif inputs['use_brewfile'].present?
+            'brew bundle'
+          else
+            'brew install'
+          end
+        end
+
+        def generate_bundler_command(inputs)
+          install_jobs = inputs['bundle_install_jobs']
+          install_retry = inputs['bundle_install_retry']
+
+          if install_jobs.present? && install_retry.present?
+            "bundle check || bundle install --jobs #{install_jobs} --retry #{install_retry}"
+          else
+            '# Invalid bundler step configuration!'
+          end
+        end
+
+        def generate_change_workdir_command(path, is_create_path)
+          if is_create_path && path.present?
+            "mkdir #{path} && cd #{path}"
+          elsif !is_create_path && path.present?
+            "cd #{path}"
+          else
+            '# Invalid change-workdir step configuration!'
+          end
+        end
+
+        def generate_git_tag_command(inputs)
+          cmd_all_params = "git tag -fa #{inputs['tag']} -m #{inputs['tag_message']} && git push --tags"
+          cmd_no_message = "git tag -fa #{inputs['tag']} && git push --tags"
+
+          if inputs['tag'].present? && inputs['push'].present?
+            inputs['tag_message'].present? ? cmd_all_params : cmd_no_message
+          else
+            '# Invalid git-tag step configuration!'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'active_support//core_ext/object/blank'
+require_relative 'commands'
 
 module BK
   module Compat
@@ -23,49 +23,16 @@ module BK
           ]
         end
 
-        def generate_brew_install_command(inputs)
-          if inputs['packages'].present? && inputs['upgrade']
-            "brew reinstall #{inputs['packages']}"
-          elsif inputs['packages'].present? && !inputs['upgrade']
-            "brew install #{inputs['packages']}"
-          elsif inputs['use_brewfile'].present?
-            'brew bundle'
-          else
-            'brew install'
-          end
-        end
-
         def translate_bundler(inputs)
           [
             generate_bundler_command(inputs)
           ]
         end
 
-        def generate_bundler_command(inputs)
-          install_jobs = inputs['bundle_install_jobs']
-          install_retry = inputs['bundle_install_retry']
-
-          if install_jobs.present? && install_retry.present?
-            "bundle check || bundle install --jobs #{install_jobs} --retry #{install_retry}"
-          else
-            '# Invalid bundler step configuration!'
-          end
-        end
-
         def translate_change_workdir(inputs)
           [
             generate_change_workdir_command(inputs['path'], inputs['is_create_path'])
           ]
-        end
-
-        def generate_change_workdir_command(path, is_create_path)
-          if is_create_path && path.present?
-            "mkdir #{path} && cd #{path}"
-          elsif !is_create_path && path.present?
-            "cd #{path}"
-          else
-            '# Invalid change-workdir step configuration!'
-          end
         end
 
         def translate_git_clone(_inputs)
@@ -76,7 +43,7 @@ module BK
 
         def translate_git_tag(inputs)
           [
-            ["To be implemented"]
+            generate_git_tag_command(inputs)
           ]
         end
 

--- a/app/lib/bk/compat/parsers/bitrise/steps.rb
+++ b/app/lib/bk/compat/parsers/bitrise/steps.rb
@@ -7,7 +7,7 @@ module BK
     module BitriseSteps
       # Implementation of Bitrise step translations
       class Translator
-        VALID_STEP_TYPES = %w[bundler brew-install change-workdir git-clone script].freeze
+        VALID_STEP_TYPES = %w[bundler brew-install change-workdir git-clone git-tag script].freeze
 
         def matcher(type, _inputs)
           VALID_STEP_TYPES.include?(type.downcase)
@@ -71,6 +71,12 @@ module BK
         def translate_git_clone(_inputs)
           [
             ['# No need for cloning, the agent takes care of that']
+          ]
+        end
+
+        def translate_git_tag(inputs)
+          [
+            ["To be implemented"]
           ]
         end
 

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-tag.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-tag.yml.snap
@@ -3,10 +3,17 @@ steps:
 - commands:
   - "# No need for cloning, the agent takes care of that"
   - "./build-app.sh"
-  - To be implemented
+  - git tag -fa $BITRISE_BUILD_NUMBER -m v1.0.0 && git push --tags
   label: build
   key: build
 - commands:
+  - "# No need for cloning, the agent takes care of that"
+  - "./test.sh"
+  - git tag -fa test-$BITRISE_BUILD_NUMBER && git push --tags
+  label: test
+  key: test
+- commands:
   - "./deploy-app.sh"
+  - "# Invalid git-tag step configuration!"
   label: deploy
   key: deploy

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-tag.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-tag.yml.snap
@@ -1,0 +1,12 @@
+---
+steps:
+- commands:
+  - "# No need for cloning, the agent takes care of that"
+  - "./build-app.sh"
+  - To be implemented
+  label: build
+  key: build
+- commands:
+  - "./deploy-app.sh"
+  label: deploy
+  key: deploy

--- a/app/spec/lib/bk/compat/bitrise/examples/git-tag.yml
+++ b/app/spec/lib/bk/compat/bitrise/examples/git-tag.yml
@@ -1,0 +1,24 @@
+format_version: 11
+default_step_lib_source: https://github.com/example/example-bitrise.git
+project_type: ios
+
+workflows:
+  build:
+    steps:
+    - git-clone@8.2.2:
+        inputs:
+        - clone_into_dir: /tmp/bitrise-ex/
+        - repository_url: git@github.com:example/example-repository.git
+    - script@1.1.5:
+        inputs:
+        - content: ./build-app.sh
+    - git-tag@1.1.0:
+        inputs:
+        - tag: $BITRISE_BUILD_NUMBER
+        - tag_message: "v1.0.0"
+        - push: true
+  deploy:
+    steps:  
+    - script@1.1.5:
+        inputs:
+        - content: ./deploy-app.sh

--- a/app/spec/lib/bk/compat/bitrise/examples/git-tag.yml
+++ b/app/spec/lib/bk/compat/bitrise/examples/git-tag.yml
@@ -17,8 +17,25 @@ workflows:
         - tag: $BITRISE_BUILD_NUMBER
         - tag_message: "v1.0.0"
         - push: true
+  test:
+    steps:
+    - git-clone@8.2.2:
+        inputs:
+        - clone_into_dir: /tmp/bitrise-ex/
+        - repository_url: git@github.com:example/example-repository.git
+    - script@1.1.5:
+        inputs:
+        - content: ./test.sh
+    - git-tag@1.1.0:
+        inputs:
+        - tag: test-$BITRISE_BUILD_NUMBER
+        - push: true
   deploy:
     steps:  
     - script@1.1.5:
         inputs:
         - content: ./deploy-app.sh
+    - git-tag@1.1.0:
+        inputs:
+        - tag: deploy-$BITRISE_BUILD_NUMBER
+        - tag_message: "v1.0.0"


### PR DESCRIPTION
This PR introduces translation of`git-tag` steps when defined in Bitrise YAML configuration.

The step takes in two inputs that are mandatory - `push` and `tag` - to specify both the `git push --tags` cmd and tag name respectfully. A third, optional inputs is `tag_message` - which can be affixed if one desires.

The logic handles the cases where the two mandatory inputs are specified with/without a message or not - otherwise for either of the first two not existing, will yield a `# Invalid git-tag step configuration!` message in the generated `CommandStep`.