### PR TITLE
SUP-2397: Workflows embedded with `GroupStep`s

### DIFF
--- a/app/lib/bk/compat/parsers/bitrise/loader.rb
+++ b/app/lib/bk/compat/parsers/bitrise/loader.rb
@@ -9,12 +9,12 @@ module BK
       def load_workflow(key, config)
         raise "Duplicate workflow name: #{key}" if @steps_by_key.include?(key)
 
-        @steps_by_key[key] = load_workflow_steps(key, config)
+        @steps_by_key[key] = load_workflow_steps(config)
       end
 
-      def load_workflow_steps(key, config)
+      def load_workflow_steps(config)
         # Extend for other types of steps - approvals/waits for example.
-        BK::Compat::CommandStep.new(label: key, key: key).tap do |cmd_step|
+        BK::Compat::CommandStep.new.tap do |cmd_step|
           config['steps'].each do |step|
             step_key, step_config = step.first
             step_inputs = step_config['inputs'].reduce({}, :merge)

--- a/app/lib/bk/compat/parsers/bitrise/workflows.rb
+++ b/app/lib/bk/compat/parsers/bitrise/workflows.rb
@@ -9,6 +9,16 @@ module BK
       def parse_workflow(wf_name, _wf_config)
         raise "No key within loaded workflow configuration for #{wf_name}" unless @steps_by_key.include?(wf_name)
 
+        bk_steps = process_workflow_steps(wf_name)
+
+        BK::Compat::GroupStep.new(
+          label: wf_name,
+          key: wf_name,
+          steps: [bk_steps]
+        )
+      end
+
+      def process_workflow_steps(wf_name)
         @steps_by_key[wf_name]
       end
     end

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/brew-install.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/brew-install.yml.snap
@@ -1,17 +1,20 @@
 ---
 steps:
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - brew reinstall jq yq git
-  label: build
+- group: build
   key: build
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - brew install jq yq git selenium-server cucumber-ruby
-  label: test
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - brew reinstall jq yq git
+- group: test
   key: test
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - brew bundle
-  label: deploy
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - brew install jq yq git selenium-server cucumber-ruby
+- group: deploy
   key: deploy
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - brew bundle

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/bundler.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/bundler.yml.snap
@@ -1,8 +1,9 @@
 ---
 steps:
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - bundle check || bundle install --jobs 4 --retry 1
-  - "./build-app.sh"
-  label: build
+- group: build
   key: build
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - bundle check || bundle install --jobs 4 --retry 1
+    - "./build-app.sh"

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/change-workdir.yml.snap
@@ -1,19 +1,22 @@
 ---
 steps:
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - mkdir bitrise-ex/build && cd bitrise-ex/build
-  - "./build-app.sh"
-  label: build
+- group: build
   key: build
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - "# Invalid change-workdir step configuration!"
-  - "./test.sh"
-  label: test
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - mkdir bitrise-ex/build && cd bitrise-ex/build
+    - "./build-app.sh"
+- group: test
   key: test
-- commands:
-  - cd bitrise-ex/deploy/
-  - "./deploy-app.sh"
-  label: deploy
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - "# Invalid change-workdir step configuration!"
+    - "./test.sh"
+- group: deploy
   key: deploy
+  steps:
+  - commands:
+    - cd bitrise-ex/deploy/
+    - "./deploy-app.sh"

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/example.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/example.yml.snap
@@ -1,6 +1,7 @@
 ---
 steps:
-- commands:
-  - echo "Hello ${MY_NAME}!"
-  label: test
+- group: test
   key: test
+  steps:
+  - commands:
+    - echo "Hello ${MY_NAME}!"

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-clone.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-clone.yml.snap
@@ -1,11 +1,13 @@
 ---
 steps:
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - "./build-app.sh"
-  label: build
+- group: build
   key: build
-- commands:
-  - "./deploy-app.sh"
-  label: deploy
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - "./build-app.sh"
+- group: deploy
   key: deploy
+  steps:
+  - commands:
+    - "./deploy-app.sh"

--- a/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-tag.yml.snap
+++ b/app/spec/lib/bk/compat/bitrise/__snapshots__/spec/lib/bk/compat/bitrise/examples/git-tag.yml.snap
@@ -1,19 +1,22 @@
 ---
 steps:
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - "./build-app.sh"
-  - git tag -fa $BITRISE_BUILD_NUMBER -m v1.0.0 && git push --tags
-  label: build
+- group: build
   key: build
-- commands:
-  - "# No need for cloning, the agent takes care of that"
-  - "./test.sh"
-  - git tag -fa test-$BITRISE_BUILD_NUMBER && git push --tags
-  label: test
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - "./build-app.sh"
+    - git tag -fa $BITRISE_BUILD_NUMBER -m v1.0.0 && git push --tags
+- group: test
   key: test
-- commands:
-  - "./deploy-app.sh"
-  - "# Invalid git-tag step configuration!"
-  label: deploy
+  steps:
+  - commands:
+    - "# No need for cloning, the agent takes care of that"
+    - "./test.sh"
+    - git tag -fa test-$BITRISE_BUILD_NUMBER && git push --tags
+- group: deploy
   key: deploy
+  steps:
+  - commands:
+    - "./deploy-app.sh"
+    - "# Invalid git-tag step configuration!"


### PR DESCRIPTION
Each `workflow` that is defined in a `bitrise.yml` can have zero to N `steps` inclusive - in which the latter is currently loaded and parsed as a `CommandStep` with appended `commands` per steps' logic.

This PR encapsulates each `workflow` to a higher-level `GroupStep` with the accompanying `label` and `key`, which have been removed from the lower level generated ``CommandStep`s. 

Specs have been refreshed for Bitrise - merging this to #147 which will all be inclusive in #141 