### PR TITLE
Migrate deploy pipeline to the OSS Deploy cluster [PLT-3175]

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -24,6 +24,12 @@ steps:
       - docker build . -t buildkite/migration-tool
       - docker push buildkite/migration-tool
     plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-migration-tool-deploy
+      - aws-ssm#v1.0.0:
+          parameters:
+            BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME: /pipelines/buildkite/migration-tool-deploy/docker-login-username
+            DOCKER_LOGIN_PASSWORD: /pipelines/buildkite/migration-tool-deploy/docker-login-password
       - docker-login#v3.0.0: ~
     if: |
       build.branch == 'main'


### PR DESCRIPTION
We're slowly migrating open source pipelines into their own clusters. This pattern includes using pipeline-specific OIDC assumable roles for access to any resources needed; and injecting secrets explicitly to steps, using the ssm plugin, rather than using s3 secrets.

The roles and ssm parameters have been created, but the cluster will need to be changed in the pipeline settings before this is merged.