### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -24,8 +24,12 @@ steps:
       - docker build . -t buildkite/migration-tool
       - docker push buildkite/migration-tool
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-migration-tool-deploy
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - aws-ssm#v1.0.0:
           parameters:
             BUILDKITE_PLUGIN_DOCKER_LOGIN_USERNAME: /pipelines/buildkite/migration-tool-deploy/docker-login-username


### PR DESCRIPTION
Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dev/pull/475