### PR TITLE
Mismatch in ruby versions

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -6,7 +6,7 @@ steps:
       - rubocop
     plugins:
       - docker#v5.11.0:
-          image: ruby:3.4.1
+          image: ruby:3.4.5
 
   - label: ":rspec: Snapshot Testing"
     command:
@@ -14,7 +14,7 @@ steps:
       - rspec spec
     plugins:
       - docker#v5.11.0:
-          image: ruby:3.4.1
+          image: ruby:3.4.5
           workdir: /app
 
   - wait: ~

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       - rubocop
     plugins:
       - docker#v5.11.0:
-          image: ruby:3.4.1
+          image: ruby:3.4.5
 
   - label: ":rspec: Snapshot Testing"
     command:
@@ -13,5 +13,5 @@ steps:
       - rspec spec
     plugins:
       - docker#v5.11.0:
-          image: ruby:3.4.1
+          image: ruby:3.4.5
           workdir: /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# If this gets updated, update pipeline images and .ruby-version
 FROM ruby:3.4.5
 
 ENV RACK_ENV=production


### PR DESCRIPTION
Found that we had 2 different ruby versions being used.

I unified them all to the latest one and added a comment in the `Dockerfile` (that is the one that gets updated by dependabot) so that we try not to forget in the future.