### PR TITLE
Add Syntax Error Handling On YAML Format Issues

### DIFF
--- a/app/.rubocop.yml
+++ b/app/.rubocop.yml
@@ -14,6 +14,7 @@ Metrics/BlockLength:
     - spec/**/*.rb
 
 Metrics/MethodLength:
+  Max: 12
   CountAsOne: [ 'array', 'hash', 'heredoc' ]
 
 Metrics/ParameterLists:

--- a/app/lib/bk/compat/error.rb
+++ b/app/lib/bk/compat/error.rb
@@ -1,10 +1,20 @@
 # frozen_string_literal: true
 
+require 'yaml'
+
 module BK
   module Compat
     # unsupported feature
     module Error
-      class CompatError < StandardError; end
+      class ParseError < StandardError; end
+
+      class CompatError < ParseError
+        def self.safe_yaml
+          yield
+        rescue Psych::SyntaxError => e
+          raise new("Invalid YAML syntax: #{e.message}")
+        end
+      end
 
       class NotSupportedError < CompatError; end
 

--- a/app/lib/bk/compat/error.rb
+++ b/app/lib/bk/compat/error.rb
@@ -8,6 +8,7 @@ module BK
     module Error
       class ParseError < StandardError; end
 
+      # Base compatibility error with YAML parsing support
       class CompatError < ParseError
         def self.safe_yaml
           yield

--- a/app/lib/bk/compat/parsers/bitbucket.rb
+++ b/app/lib/bk/compat/parsers/bitbucket.rb
@@ -32,7 +32,7 @@ module BK
 
         config.is_a?(Hash) && mandatory_keys & config.keys == mandatory_keys
       rescue Psych::SyntaxError
-        return false
+        false
       end
 
       def initialize(text, options = {})

--- a/app/lib/bk/compat/parsers/bitbucket.rb
+++ b/app/lib/bk/compat/parsers/bitbucket.rb
@@ -31,6 +31,8 @@ module BK
         mandatory_keys = %w[pipelines].freeze
 
         config.is_a?(Hash) && mandatory_keys & config.keys == mandatory_keys
+      rescue Psych::SyntaxError
+        return false
       end
 
       def initialize(text, options = {})
@@ -38,6 +40,8 @@ module BK
         @options = options
 
         register_translators!
+      rescue Psych::SyntaxError => e
+        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/bitbucket.rb
+++ b/app/lib/bk/compat/parsers/bitbucket.rb
@@ -36,12 +36,12 @@ module BK
       end
 
       def initialize(text, options = {})
-        @config = YAML.safe_load(text, aliases: true)
-        @options = options
+        BK::Compat::Error::CompatError.safe_yaml do
+          @config = YAML.safe_load(text, aliases: true)
+          @options = options
 
-        register_translators!
-      rescue Psych::SyntaxError => e
-        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
+          register_translators!
+        end
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/bitrise.rb
+++ b/app/lib/bk/compat/parsers/bitrise.rb
@@ -27,6 +27,8 @@ module BK
         mandatory_keys = %w[format_version].freeze
 
         config.is_a?(Hash) && mandatory_keys & config.keys == mandatory_keys
+      rescue Psych::SyntaxError
+        return false
       end
 
       def initialize(text, options = {})
@@ -34,6 +36,8 @@ module BK
         @options = options
 
         register_translators!
+      rescue Psych::SyntaxError => e
+        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/bitrise.rb
+++ b/app/lib/bk/compat/parsers/bitrise.rb
@@ -32,12 +32,12 @@ module BK
       end
 
       def initialize(text, options = {})
-        @config = YAML.safe_load(text, aliases: true)
-        @options = options
+        BK::Compat::Error::CompatError.safe_yaml do
+          @config = YAML.safe_load(text, aliases: true)
+          @options = options
 
-        register_translators!
-      rescue Psych::SyntaxError => e
-        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
+          register_translators!
+        end
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/bitrise.rb
+++ b/app/lib/bk/compat/parsers/bitrise.rb
@@ -28,7 +28,7 @@ module BK
 
         config.is_a?(Hash) && mandatory_keys & config.keys == mandatory_keys
       rescue Psych::SyntaxError
-        return false
+        false
       end
 
       def initialize(text, options = {})

--- a/app/lib/bk/compat/parsers/circleci.rb
+++ b/app/lib/bk/compat/parsers/circleci.rb
@@ -46,7 +46,7 @@ module BK
           config.fetch('version', 2.1) == 2 && config['jobs'].include?('build')
         end
       rescue Psych::SyntaxError
-        return false
+        false
       end
 
       def initialize(text, options = {})

--- a/app/lib/bk/compat/parsers/circleci.rb
+++ b/app/lib/bk/compat/parsers/circleci.rb
@@ -50,15 +50,15 @@ module BK
       end
 
       def initialize(text, options = {})
-        @config = YAML.safe_load(text, aliases: true)
-        @now = Time.now
-        @options = options
-        @commands_by_key = {}
-        @executors = {}
+        BK::Compat::Error::CompatError.safe_yaml do
+          @config = YAML.safe_load(text, aliases: true)
+          @now = Time.now
+          @options = options
+          @commands_by_key = {}
+          @executors = {}
 
-        register_translators!
-      rescue Psych::SyntaxError => e
-        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
+          register_translators!
+        end
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/circleci.rb
+++ b/app/lib/bk/compat/parsers/circleci.rb
@@ -45,6 +45,8 @@ module BK
           # legacy format support
           config.fetch('version', 2.1) == 2 && config['jobs'].include?('build')
         end
+      rescue Psych::SyntaxError
+        return false
       end
 
       def initialize(text, options = {})
@@ -55,6 +57,8 @@ module BK
         @executors = {}
 
         register_translators!
+      rescue Psych::SyntaxError => e
+        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/gha.rb
+++ b/app/lib/bk/compat/parsers/gha.rb
@@ -27,17 +27,17 @@ module BK
         config = YAML.safe_load(text)
         # YAML translates the `on` key in YAML to ruby's `true` boolean
         mandatory_keys = ['jobs', true]
-        
+
         config.is_a?(Hash) && mandatory_keys & config.keys == mandatory_keys
       rescue Psych::SyntaxError
-        return false
+        false
       end
 
       def initialize(text, options = {})
         BK::Compat::Error::CompatError.safe_yaml do
           @config = YAML.safe_load(text)
           @options = options
-          
+
           register_translators!
         end
       end

--- a/app/lib/bk/compat/parsers/gha.rb
+++ b/app/lib/bk/compat/parsers/gha.rb
@@ -27,15 +27,19 @@ module BK
         config = YAML.safe_load(text)
         # YAML translates the `on` key in YAML to ruby's `true` boolean
         mandatory_keys = ['jobs', true]
-
+        
         config.is_a?(Hash) && mandatory_keys & config.keys == mandatory_keys
+      rescue Psych::SyntaxError
+        return false
       end
 
       def initialize(text, options = {})
         @config = YAML.safe_load(text)
         @options = options
-
+        
         register_translators!
+      rescue Psych::SyntaxError => e
+        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/gha.rb
+++ b/app/lib/bk/compat/parsers/gha.rb
@@ -34,12 +34,12 @@ module BK
       end
 
       def initialize(text, options = {})
-        @config = YAML.safe_load(text)
-        @options = options
-        
-        register_translators!
-      rescue Psych::SyntaxError => e
-        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
+        BK::Compat::Error::CompatError.safe_yaml do
+          @config = YAML.safe_load(text)
+          @options = options
+          
+          register_translators!
+        end
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/harness.rb
+++ b/app/lib/bk/compat/parsers/harness.rb
@@ -32,7 +32,7 @@ module BK
           false
         end
       rescue Psych::SyntaxError
-        return false
+        false
       end
 
       def initialize(text, options = {})

--- a/app/lib/bk/compat/parsers/harness.rb
+++ b/app/lib/bk/compat/parsers/harness.rb
@@ -31,6 +31,8 @@ module BK
         else
           false
         end
+      rescue Psych::SyntaxError
+        return false
       end
 
       def initialize(text, options = {})
@@ -38,6 +40,8 @@ module BK
         @options = options
 
         register_translators!
+      rescue Psych::SyntaxError => e
+        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/harness.rb
+++ b/app/lib/bk/compat/parsers/harness.rb
@@ -36,12 +36,12 @@ module BK
       end
 
       def initialize(text, options = {})
-        @config = YAML.safe_load(text, aliases: true)
-        @options = options
+        BK::Compat::Error::CompatError.safe_yaml do
+          @config = YAML.safe_load(text, aliases: true)
+          @options = options
 
-        register_translators!
-      rescue Psych::SyntaxError => e
-        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
+          register_translators!
+        end
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/jenkins.rb
+++ b/app/lib/bk/compat/parsers/jenkins.rb
@@ -33,12 +33,12 @@ module BK
       end
 
       def initialize(text, options = {})
-        @config = YAML.safe_load(text)
-        @options = options
+        BK::Compat::Error::CompatError.safe_yaml do
+          @config = YAML.safe_load(text)
+          @options = options
 
-        register_translators!
-      rescue Psych::SyntaxError => e
-        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
+          register_translators!
+        end
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/jenkins.rb
+++ b/app/lib/bk/compat/parsers/jenkins.rb
@@ -28,6 +28,8 @@ module BK
 
         # Mandatory keys are part of the pipeline element
         config.is_a?(Hash) && mandatory_keys & config.fetch('pipeline', {}).keys == mandatory_keys
+      rescue Psych::SyntaxError
+        return false
       end
 
       def initialize(text, options = {})
@@ -35,6 +37,8 @@ module BK
         @options = options
 
         register_translators!
+      rescue Psych::SyntaxError => e
+        raise BK::Compat::Error::ConfigurationError, "Invalid YAML syntax: #{e.message}"
       end
 
       def parse

--- a/app/lib/bk/compat/parsers/jenkins.rb
+++ b/app/lib/bk/compat/parsers/jenkins.rb
@@ -29,7 +29,7 @@ module BK
         # Mandatory keys are part of the pipeline element
         config.is_a?(Hash) && mandatory_keys & config.fetch('pipeline', {}).keys == mandatory_keys
       rescue Psych::SyntaxError
-        return false
+        false
       end
 
       def initialize(text, options = {})

--- a/app/lib/bk/compat/server.rb
+++ b/app/lib/bk/compat/server.rb
@@ -52,17 +52,15 @@ module BK
         parser = BK::Compat.guess(contents)
         if parser.nil?
           # Try to detect if it's a YAML syntax error
-          begin
+          BK::Compat::Error::CompatError.safe_yaml do
             YAML.safe_load(contents)
             return error_message('Parser could not be identified.')
-          rescue Psych::SyntaxError => e
-            return error_message("Invalid YAML syntax: #{e.message}")
           end
         end
 
         body = parser.new(contents).parse.render(colors: false, format: format)
         success_message(body, content_type: content_type)
-      rescue BK::Compat::Error::CompatError => e
+      rescue BK::Compat::Error::ParseError => e
         error_message(e.message, code: 501)
       rescue StandardError
         error_message(

--- a/app/lib/bk/compat/server.rb
+++ b/app/lib/bk/compat/server.rb
@@ -73,7 +73,13 @@ module BK
         # Try to detect if it's a YAML syntax error
         BK::Compat::Error::CompatError.safe_yaml do
           YAML.safe_load(contents)
-          return error_message('Parser could not be identified. Please ensure your file is valid YAML for a supported CI platform (GitHub Actions, CircleCI, Jenkins, Bitbucket, Bitrise, or Harness).')
+          return error_message(
+            [
+              'Parser could not be identified.',
+              'Please ensure your file is valid YAML for a supported CI platform',
+              '(GitHub Actions, CircleCI, Jenkins, Bitbucket, Bitrise, or Harness).'
+            ]
+          )
         end
       end
 

--- a/app/lib/bk/compat/server.rb
+++ b/app/lib/bk/compat/server.rb
@@ -73,7 +73,7 @@ module BK
         # Try to detect if it's a YAML syntax error
         BK::Compat::Error::CompatError.safe_yaml do
           YAML.safe_load(contents)
-          return error_message('Parser could not be identified.')
+          return error_message('Parser could not be identified. Please ensure your file is valid YAML for a supported CI platform (GitHub Actions, CircleCI, Jenkins, Bitbucket, Bitrise, or Harness).')
         end
       end
 


### PR DESCRIPTION
-  Return an error message when a YAML formatting issue is encountered instead of having the tool crash. This includes error handling of `Psych::SyntaxError` exceptions. 
- Increased MethodLength limit to cater to the added error handling of exceptions in code.  Additional lines in code to catch the exception has caused the circleci `self.matches?` method exceed the MethodLength in `rubocop` and returned a Lint Error.  