### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @toote @pzeballos @james2791
+* @toote @pzeballos
+* @buildkite/support-engineering


### PR DESCRIPTION
## Changes

- Removes James Sammut as he doesn't even go here anymore
- Adds support engineers

### Caveats

- This will likely require the Support Engineers team be given access to the repo, however I cannot access `Settings`
